### PR TITLE
Ported the SCHEDULAR Fix to 1.20

### DIFF
--- a/common/src/main/java/software/bluelib/BlueLibConstants.java
+++ b/common/src/main/java/software/bluelib/BlueLibConstants.java
@@ -45,14 +45,14 @@ public class BlueLibConstants {
     public static final Logger LOGGER = Logger.getLogger(BlueLibConstants.MOD_NAME);
 
     /**
-     * A {@code public static final} {@link ScheduledExecutorService} used to schedule tasks, such as printing messages after a delay.
+     * A {@code public static} {@link ScheduledExecutorService} used to schedule tasks, such as printing messages after a delay.
      * <p>
      * This executor runs tasks on a single thread to ensure delayed tasks run in a separate thread from the main thread.
      * </p>
      *
      * @since 1.0.0
      */
-    public static final ScheduledExecutorService SCHEDULER = Executors.newScheduledThreadPool(1);
+    public static ScheduledExecutorService SCHEDULER = Executors.newScheduledThreadPool(1);
 
     /**
      * A {@code public static final} {@link String} representing the Mod ID for the {@code BlueLib} mod.

--- a/fabric/src/main/java/software/bluelib/example/event/ReloadHandler.java
+++ b/fabric/src/main/java/software/bluelib/example/event/ReloadHandler.java
@@ -11,6 +11,7 @@ import software.bluelib.utils.logging.BaseLogger;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -50,6 +51,7 @@ public class ReloadHandler extends ReloadEventHandler {
      * @since 1.0.0
      */
     public static void onServerStart(MinecraftServer pServer) {
+        BlueLibConstants.SCHEDULER = new ScheduledThreadPoolExecutor(1);
         server = pServer;
         ReloadHandler.LoadEntityVariants(server);
         BaseLogger.log(BaseLogLevel.INFO, "Entity variants loaded.", true);

--- a/forge/src/main/java/software/bluelib/example/event/ReloadHandler.java
+++ b/forge/src/main/java/software/bluelib/example/event/ReloadHandler.java
@@ -13,6 +13,7 @@ import software.bluelib.utils.logging.BaseLogger;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -53,6 +54,7 @@ public class ReloadHandler extends ReloadEventHandler {
      */
     @SubscribeEvent
     public static void onServerStart(ServerStartingEvent pEvent) {
+        BlueLibConstants.SCHEDULER = new ScheduledThreadPoolExecutor(1);
         server = pEvent.getServer();
         ReloadHandler.LoadEntityVariants(server);
         BaseLogger.log(BaseLogLevel.INFO, "Entity variants loaded.", true);

--- a/neoforge/src/main/java/software/bluelib/example/event/ReloadHandler.java
+++ b/neoforge/src/main/java/software/bluelib/example/event/ReloadHandler.java
@@ -14,6 +14,7 @@ import software.bluelib.utils.logging.BaseLogger;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -56,6 +57,7 @@ public class ReloadHandler extends ReloadEventHandler {
      */
     @SubscribeEvent
     public static void onServerStart(ServerStartingEvent pEvent) {
+        BlueLibConstants.SCHEDULER = new ScheduledThreadPoolExecutor(1);
         server = pEvent.getServer();
         ReloadHandler.LoadEntityVariants(server);
         BaseLogger.log(BaseLogLevel.INFO, "Entity variants loaded.", true);


### PR DESCRIPTION
## Description
Ensured that the SCHEDULAR is being restarted when you join a world to ensure it is always online.

## Changes
- **Change 1**: Ensured that the SCHEDULAR is being restarted when you join a world

## How has this been tested?
* Join a world
* Save and Leave
* Rejoin and see if the SCHEDULAR is still active

## Screenshots (if applicable)
<!-- Add screenshots to explain the visual impact of the changes. -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

## Checklist
- [x] My code follows the style guidelines of this project. [Contributing](https://github.com/MeAlam1/BlueLib/blob/1.21/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code.
- [x] I have commented my code following the guidelines. [Contributing](https://github.com/MeAlam1/BlueLib/blob/1.21/CONTRIBUTING.md)
- [x] My changes generate no new warnings.

## Related Issues
* Got the issue through Discord

---------

Co-Authored-By: Bluedude <68448043+Dan6335@users.noreply.github.com>