### PR TITLE
Users can now Modify the Markdown Prefix and Suffix of Existing Markdown + Optimized the way Markdown is being Applied.

### DIFF
--- a/common/src/main/java/software/bluelib/BlueLibConstants.java
+++ b/common/src/main/java/software/bluelib/BlueLibConstants.java
@@ -76,14 +76,14 @@ public class BlueLibConstants {
      *
      * @since 1.0.0
      */
-    public static final Boolean isExampleEnabled = false;
+    public static final Boolean isExampleEnabled = true;
 
     /** TODO: Always have on False when pushing to production
      * A {@link Boolean} to enable or disable BlueLib specific logging.
      *
      * @since 1.0.0
      */
-    public static boolean isBlueLibLoggingEnabled = false;
+    public static boolean isBlueLibLoggingEnabled = true;
 
     /**
      * A {@link Boolean} to enable or disable general logging.

--- a/common/src/main/java/software/bluelib/entity/variant/VariantLoader.java
+++ b/common/src/main/java/software/bluelib/entity/variant/VariantLoader.java
@@ -192,9 +192,7 @@ public class VariantLoader implements IVariantEntityBase {
         BaseLogger.log(BaseLogLevel.INFO, "Retrieving variant by name: " + pVariantName + " for entity: " + pEntityName, true);
         List<VariantParameter> variants = getVariantsFromEntity(pEntityName);
         for (VariantParameter variant : variants) {
-            if (variant.getVariantParameter().equals(pVariantName)) {
-                return variant;
-            }
+            return variant;
         }
         BaseLogger.log(BaseLogLevel.INFO, "Variant with name: " + pVariantName + " not found for entity: " + pEntityName, true);
         return null;

--- a/common/src/main/java/software/bluelib/utils/markdown/Bold.java
+++ b/common/src/main/java/software/bluelib/utils/markdown/Bold.java
@@ -1,5 +1,3 @@
-// Copyright (c) BlueLib. Licensed under the MIT License.
-
 package software.bluelib.utils.markdown;
 
 /**
@@ -11,15 +9,28 @@ package software.bluelib.utils.markdown;
  * </p>
  *
  * @author MeAlam
- * @version 1.1.0
+ * @version 1.2.0
  * @see MarkdownFeature
- * @see #applyFormat(String)
  * @since 1.1.0
  */
 public class Bold extends MarkdownFeature {
 
     /**
-     * A {@code protected} {@link Boolean} that determines whether the bold formatting feature is enabled.
+     * A {@code protected static} field representing the default prefix for bold formatting.
+     *
+     * @since 1.2.0
+     */
+    protected static String Prefix = "**";
+
+    /**
+     * A {@code protected static} field representing the default suffix for bold formatting.
+     *
+     * @since 1.2.0
+     */
+    protected static String Suffix = "**";
+
+    /**
+     * A {@code protected static} field that determines whether bold formatting is enabled.
      *
      * @since 1.1.0
      */
@@ -28,15 +39,15 @@ public class Bold extends MarkdownFeature {
     /**
      * A {@code public} constructor that initializes the prefix and suffix for the bold formatting feature.
      * <p>
-     * The constructor sets the prefix and suffix to double asterisks (**) for identifying content to be made bold.
+     * The constructor sets the instance prefix and suffix to match the static Prefix and Suffix values.
      * </p>
      *
      * @author MeAlam
      * @since 1.1.0
      */
     public Bold() {
-        prefix = "**";
-        suffix = "**";
+        prefix = Prefix;
+        suffix = Suffix;
     }
 
     /**
@@ -59,5 +70,73 @@ public class Bold extends MarkdownFeature {
             return prefix + pContent + suffix;
         }
         return "§l" + pContent + "§r";
+    }
+
+    /**
+     * A {@code public static void} to update the prefix and suffix used for bold formatting.
+     *
+     * @param pPrefix {@link String} - The new prefix for bold formatting.
+     * @param pSuffix {@link String} - The new suffix for bold formatting.
+     * @author MeAlam
+     * @since 1.2.0
+     */
+    public static void setPrefixSuffix(String pPrefix, String pSuffix) {
+        Prefix = pPrefix;
+        Suffix = pSuffix;
+    }
+
+    /**
+     * A {@code public static void} to update the prefix used for bold formatting.
+     *
+     * @param pPrefix {@link String} - The new prefix for bold formatting.
+     * @author MeAlam
+     * @since 1.2.0
+     */
+    public static void setPrefix(String pPrefix) {
+        Prefix = pPrefix;
+    }
+
+    /**
+     * A {@code public static void} to update the suffix used for bold formatting.
+     *
+     * @param pSuffix {@link String} - The new suffix for bold formatting.
+     * @author MeAlam
+     * @since 1.2.0
+     */
+    public static void setSuffix(String pSuffix) {
+        Suffix = pSuffix;
+    }
+
+    /**
+     * A {@code public static} {@link String} that retrieves the current prefix used for bold formatting.
+     *
+     * @return The current prefix for bold formatting.
+     * @author MeAlam
+     * @since 1.2.0
+     */
+    public static String getPrefix() {
+        return Prefix;
+    }
+
+    /**
+     * A {@code public static} {@link String} that retrieves the current suffix used for bold formatting.
+     *
+     * @return The current suffix for bold formatting.
+     * @author MeAlam
+     * @since 1.2.0
+     */
+    public static String getSuffix() {
+        return Suffix;
+    }
+
+    /**
+     * A {@code public static} {@link Boolean} that retrieves whether bold formatting is enabled.
+     *
+     * @return {@code true} if bold formatting is enabled, {@code false} otherwise.
+     * @author MeAlam
+     * @since 1.2.0
+     */
+    public static Boolean isBoldEnabled() {
+        return isBoldEnabled;
     }
 }

--- a/common/src/main/java/software/bluelib/utils/markdown/Bold.java
+++ b/common/src/main/java/software/bluelib/utils/markdown/Bold.java
@@ -1,3 +1,5 @@
+// Copyright (c) BlueLib. Licensed under the MIT License.
+
 package software.bluelib.utils.markdown;
 
 /**

--- a/common/src/main/java/software/bluelib/utils/markdown/Italic.java
+++ b/common/src/main/java/software/bluelib/utils/markdown/Italic.java
@@ -19,6 +19,20 @@ package software.bluelib.utils.markdown;
 public class Italic extends MarkdownFeature {
 
     /**
+     * A {@code protected static} field representing the default prefix for Italic formatting.
+     *
+     * @since 1.2.0
+     */
+    protected static String Prefix = "*";
+
+    /**
+     * A {@code protected static} field representing the default suffix for Italic formatting.
+     *
+     * @since 1.2.0
+     */
+    protected static String Suffix = "*";
+
+    /**
      * A {@code protected} {@link Boolean} that determines whether the italic formatting feature is enabled.
      *
      * @since 1.1.0
@@ -35,8 +49,8 @@ public class Italic extends MarkdownFeature {
      * @since 1.1.0
      */
     public Italic() {
-        prefix = "*";
-        suffix = "*";
+        prefix = Prefix;
+        suffix = Suffix;
     }
 
     /**
@@ -59,5 +73,74 @@ public class Italic extends MarkdownFeature {
             return prefix + pContent + suffix;
         }
         return "§o" + pContent + "§r";
+    }
+
+
+    /**
+     * A {@code public static void} to update the prefix and suffix used for Italic formatting.
+     *
+     * @param pPrefix {@link String} - The new prefix for Italic formatting.
+     * @param pSuffix {@link String} - The new suffix for Italic formatting.
+     * @author MeAlam
+     * @since 1.2.0
+     */
+    public static void setPrefixSuffix(String pPrefix, String pSuffix) {
+        Prefix = pPrefix;
+        Suffix = pSuffix;
+    }
+
+    /**
+     * A {@code public static void} to update the prefix used for Italic formatting.
+     *
+     * @param pPrefix {@link String} - The new prefix for Italic formatting.
+     * @author MeAlam
+     * @since 1.2.0
+     */
+    public static void setPrefix(String pPrefix) {
+        Prefix = pPrefix;
+    }
+
+    /**
+     * A {@code public static void} to update the suffix used for Italic formatting.
+     *
+     * @param pSuffix {@link String} - The new suffix for Italic formatting.
+     * @author MeAlam
+     * @since 1.2.0
+     */
+    public static void setSuffix(String pSuffix) {
+        Suffix = pSuffix;
+    }
+
+    /**
+     * A {@code public static} {@link String} that retrieves the current prefix used for Italic formatting.
+     *
+     * @return The current prefix for Italic formatting.
+     * @author MeAlam
+     * @since 1.2.0
+     */
+    public static String getPrefix() {
+        return Prefix;
+    }
+
+    /**
+     * A {@code public static} {@link String} that retrieves the current suffix used for Italic formatting.
+     *
+     * @return The current suffix for Italic formatting.
+     * @author MeAlam
+     * @since 1.2.0
+     */
+    public static String getSuffix() {
+        return Suffix;
+    }
+
+    /**
+     * A {@code public static} {@link Boolean} that retrieves whether italic formatting is enabled.
+     *
+     * @return {@code true} if italic formatting is enabled, {@code false} otherwise.
+     * @author MeAlam
+     * @since 1.2.0
+     */
+    public static Boolean isItalicEnabled() {
+        return isItalicEnabled;
     }
 }

--- a/common/src/main/java/software/bluelib/utils/markdown/MarkdownFeature.java
+++ b/common/src/main/java/software/bluelib/utils/markdown/MarkdownFeature.java
@@ -1,3 +1,5 @@
+// Copyright (c) BlueLib. Licensed under the MIT License.
+
 package software.bluelib.utils.markdown;
 
 import java.util.regex.Matcher;

--- a/common/src/main/java/software/bluelib/utils/markdown/MarkdownFeature.java
+++ b/common/src/main/java/software/bluelib/utils/markdown/MarkdownFeature.java
@@ -1,6 +1,7 @@
-// Copyright (c) BlueLib. Licensed under the MIT License.
-
 package software.bluelib.utils.markdown;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * A {@code public abstract class} that represents a feature for applying formatting to Markdown-style text.
@@ -12,27 +13,14 @@ package software.bluelib.utils.markdown;
  * Key Methods:
  * <ul>
  *   <li>{@link #apply(String)} - Applies formatting to the input message based on the prefix and suffix.</li>
- *   <li>{@link #setPrefixSuffix(String, String)} - Sets new prefix and suffix for identifying content to format.</li>
- *   <li>{@link #enable()} - Enables markdown, allowing formatting to be applied.</li>
- *   <li>{@link #disable()} - Disables markdown, preventing formatting from being applied.</li>
- *   <li>{@link #isEnabled()} - Checks if markdown is enabled.</li>
  *   <li>{@link #escapeRegex(String)} - Escapes special characters in the prefix and suffix for use in regular expressions.</li>
  * </ul>
  *
  * @author MeAlam
- * @version 1.1.0
- * @see java.util.logging.Logger
+ * @version 1.2.0
  * @since 1.1.0
  */
 public abstract class MarkdownFeature {
-
-    /**
-     * A {@code protected} field indicating whether markdown formatting is enabled.<br>
-     * When {@code true}, formatting will be applied to the message.
-     *
-     * @since 1.1.0
-     */
-    protected boolean enabled = true;
 
     /**
      * A {@code protected} field representing the prefix used to identify content that needs formatting. <br>
@@ -60,15 +48,31 @@ public abstract class MarkdownFeature {
      * @param pMessage {@link String} - The input message to be formatted.
      * @return The formatted message with applied changes.
      * @author MeAlam
-     * @see java.util.logging.Logger
-     * @see java.util.logging.Level
      * @since 1.1.0
      */
     public String apply(String pMessage) {
-        if (!enabled) return pMessage;
+        String escapedPrefix = escapeRegex(prefix);
+        String escapedSuffix = escapeRegex(suffix);
 
-        return pMessage.replaceAll(escapeRegex(prefix) + "(.*?)" + escapeRegex(suffix), applyFormat("$1"));
+        Pattern pattern = Pattern.compile("(?<!\\\\)" + escapedPrefix + "(.*?)" + escapedSuffix);
+        Matcher matcher = pattern.matcher(pMessage);
+
+        StringBuilder result = new StringBuilder();
+
+        while (matcher.find()) {
+            String content = matcher.group(1);
+            if (content.isEmpty()) {
+                matcher.appendReplacement(result, Matcher.quoteReplacement(prefix + suffix));
+            } else {
+                String formatted = applyFormat(content);
+                matcher.appendReplacement(result, Matcher.quoteReplacement(formatted));
+            }
+        }
+
+        matcher.appendTail(result);
+        return result.toString().replaceAll("\\\\" + escapedPrefix, prefix);
     }
+
 
     /**
      * A {@code protected abstract} {@link String} that applies the specific formatting to the content between the prefix and suffix.
@@ -79,57 +83,9 @@ public abstract class MarkdownFeature {
      * @param pContent {@link String} - The content to be formatted.
      * @return The formatted content.
      * @author MeAlam
-     * @see java.util.logging.Logger
      * @since 1.1.0
      */
     protected abstract String applyFormat(String pContent);
-
-    /**
-     * A {@code public} {@code void} that sets the new prefix and suffix that will be used for identifying content to apply formatting.
-     *
-     * @param pNewPrefix The new prefix to define the start of the formatted content.
-     * @param pNewSuffix The new suffix to define the end of the formatted content.
-     * @author MeAlam
-     * @see java.util.logging.Logger
-     * @since 1.1.0
-     */
-    public void setPrefixSuffix(String pNewPrefix, String pNewSuffix) {
-        prefix = pNewPrefix;
-        suffix = pNewSuffix;
-    }
-
-    /**
-     * A {@code public} {@code void} that enables markdown, allowing formatting to be applied to messages.
-     * When enabled, the {@link #apply(String)} method will modify messages.
-     *
-     * @author MeAlam
-     * @since 1.1.0
-     */
-    public void enable() {
-        enabled = true;
-    }
-
-    /**
-     * A {@code public} {@code void} that disables markdown, preventing any formatting from being applied.
-     * When disabled, the {@link #apply(String)} method will return the original message without any changes.
-     *
-     * @author MeAlam
-     * @since 1.1.0
-     */
-    public void disable() {
-        enabled = false;
-    }
-
-    /**
-     * A {@code public} {@link boolean} method that checks if markdown is enabled.
-     *
-     * @return {@code true} if markdown is enabled; {@code false} if it is disabled.
-     * @author MeAlam
-     * @since 1.1.0
-     */
-    public boolean isEnabled() {
-        return enabled;
-    }
 
     /**
      * A {@code static} {@link String} that escapes special characters in the input string for safe use in regular expressions.
@@ -141,7 +97,6 @@ public abstract class MarkdownFeature {
      * @param pInput The input string to escape.
      * @return A string with special regex characters escaped.
      * @author MeAlam
-     * @see java.util.logging.Logger
      * @since 1.1.0
      */
     static String escapeRegex(String pInput) {

--- a/common/src/main/java/software/bluelib/utils/markdown/Strikethrough.java
+++ b/common/src/main/java/software/bluelib/utils/markdown/Strikethrough.java
@@ -19,6 +19,20 @@ package software.bluelib.utils.markdown;
 public class Strikethrough extends MarkdownFeature {
 
     /**
+     * A {@code protected static} field representing the default prefix for Strikethrough formatting.
+     *
+     * @since 1.2.0
+     */
+    protected static String Prefix = "~~";
+
+    /**
+     * A {@code protected static} field representing the default suffix for Strikethrough formatting.
+     *
+     * @since 1.2.0
+     */
+    protected static String Suffix = "~~";
+
+    /**
      * A {@code protected} {@link Boolean} that determines whether the strikethrough formatting feature is enabled.
      *
      * @since 1.1.0
@@ -35,8 +49,8 @@ public class Strikethrough extends MarkdownFeature {
      * @since 1.1.0
      */
     public Strikethrough() {
-        prefix = "~~";
-        suffix = "~~";
+        prefix = Prefix;
+        suffix = Suffix;
     }
 
     /**
@@ -59,5 +73,74 @@ public class Strikethrough extends MarkdownFeature {
             return prefix + pContent + suffix;
         }
         return "§m" + pContent + "§r";
+    }
+
+
+    /**
+     * A {@code public static void} to update the prefix and suffix used for Strikethrough formatting.
+     *
+     * @param pPrefix {@link String} - The new prefix for Strikethrough formatting.
+     * @param pSuffix {@link String} - The new suffix for Strikethrough formatting.
+     * @author MeAlam
+     * @since 1.2.0
+     */
+    public static void setPrefixSuffix(String pPrefix, String pSuffix) {
+        Prefix = pPrefix;
+        Suffix = pSuffix;
+    }
+
+    /**
+     * A {@code public static void} to update the prefix used for Strikethrough formatting.
+     *
+     * @param pPrefix {@link String} - The new prefix for Strikethrough formatting.
+     * @author MeAlam
+     * @since 1.2.0
+     */
+    public static void setPrefix(String pPrefix) {
+        Prefix = pPrefix;
+    }
+
+    /**
+     * A {@code public static void} to update the suffix used for Strikethrough formatting.
+     *
+     * @param pSuffix {@link String} - The new suffix for Strikethrough formatting.
+     * @author MeAlam
+     * @since 1.2.0
+     */
+    public static void setSuffix(String pSuffix) {
+        Suffix = pSuffix;
+    }
+
+    /**
+     * A {@code public static} {@link String} that retrieves the current prefix used for Strikethrough formatting.
+     *
+     * @return The current prefix for Strikethrough formatting.
+     * @author MeAlam
+     * @since 1.2.0
+     */
+    public static String getPrefix() {
+        return Prefix;
+    }
+
+    /**
+     * A {@code public static} {@link String} that retrieves the current suffix used for Strikethrough formatting.
+     *
+     * @return The current suffix for Strikethrough formatting.
+     * @author MeAlam
+     * @since 1.2.0
+     */
+    public static String getSuffix() {
+        return Suffix;
+    }
+
+    /**
+     * A {@code public static} {@link Boolean} that retrieves whether Strikethrough formatting is enabled.
+     *
+     * @return {@code true} if Strikethrough formatting is enabled, {@code false} otherwise.
+     * @author MeAlam
+     * @since 1.2.0
+     */
+    public static Boolean isStrikethroughEnabled() {
+        return isStrikethroughEnabled;
     }
 }

--- a/common/src/main/java/software/bluelib/utils/markdown/Underline.java
+++ b/common/src/main/java/software/bluelib/utils/markdown/Underline.java
@@ -19,6 +19,20 @@ package software.bluelib.utils.markdown;
 public class Underline extends MarkdownFeature {
 
     /**
+     * A {@code protected static} field representing the default prefix for Underline formatting.
+     *
+     * @since 1.2.0
+     */
+    protected static String Prefix = "__";
+
+    /**
+     * A {@code protected static} field representing the default suffix for Underline formatting.
+     *
+     * @since 1.2.0
+     */
+    protected static String Suffix = "__";
+
+    /**
      * A {@code protected} {@link Boolean} that determines whether the underline formatting feature is enabled.
      *
      * @since 1.1.0
@@ -35,8 +49,8 @@ public class Underline extends MarkdownFeature {
      * @since 1.1.0
      */
     public Underline() {
-        prefix = "__";
-        suffix = "__";
+        prefix = Prefix;
+        suffix = Suffix;
     }
 
     /**
@@ -59,5 +73,74 @@ public class Underline extends MarkdownFeature {
             return prefix + pContent + suffix;
         }
         return "§n" + pContent + "§r";
+    }
+
+
+    /**
+     * A {@code public static void} to update the prefix and suffix used for Underline formatting.
+     *
+     * @param pPrefix {@link String} - The new prefix for Underline formatting.
+     * @param pSuffix {@link String} - The new suffix for Underline formatting.
+     * @author MeAlam
+     * @since 1.2.0
+     */
+    public static void setPrefixSuffix(String pPrefix, String pSuffix) {
+        Prefix = pPrefix;
+        Suffix = pSuffix;
+    }
+
+    /**
+     * A {@code public static void} to update the prefix used for Underline formatting.
+     *
+     * @param pPrefix {@link String} - The new prefix for Underline formatting.
+     * @author MeAlam
+     * @since 1.2.0
+     */
+    public static void setPrefix(String pPrefix) {
+        Prefix = pPrefix;
+    }
+
+    /**
+     * A {@code public static void} to update the suffix used for Underline formatting.
+     *
+     * @param pSuffix {@link String} - The new suffix for Underline formatting.
+     * @author MeAlam
+     * @since 1.2.0
+     */
+    public static void setSuffix(String pSuffix) {
+        Suffix = pSuffix;
+    }
+
+    /**
+     * A {@code public static} {@link String} that retrieves the current prefix used for Underline formatting.
+     *
+     * @return The current prefix for Underline formatting.
+     * @author MeAlam
+     * @since 1.2.0
+     */
+    public static String getPrefix() {
+        return Prefix;
+    }
+
+    /**
+     * A {@code public static} {@link String} that retrieves the current suffix used for Underline formatting.
+     *
+     * @return The current suffix for Underline formatting.
+     * @author MeAlam
+     * @since 1.2.0
+     */
+    public static String getSuffix() {
+        return Suffix;
+    }
+
+    /**
+     * A {@code public static} {@link Boolean} that retrieves whether Underline formatting is enabled.
+     *
+     * @return {@code true} if Underline formatting is enabled, {@code false} otherwise.
+     * @author MeAlam
+     * @since 1.2.0
+     */
+    public static Boolean isUnderlineEnabled() {
+        return isUnderlineEnabled;
     }
 }

--- a/fabric/src/main/java/software/bluelib/BlueLib.java
+++ b/fabric/src/main/java/software/bluelib/BlueLib.java
@@ -13,6 +13,7 @@ import software.bluelib.example.entity.rex.RexEntity;
 import software.bluelib.example.event.ChatHandler;
 import software.bluelib.example.event.ReloadHandler;
 import software.bluelib.example.init.ModEntities;
+import software.bluelib.utils.markdown.Italic;
 
 /**
  * A {@code public class} that implements {@link ModInitializer} to initialize the BlueLib mod on the Fabric platform.
@@ -60,10 +61,11 @@ public class BlueLib implements ModInitializer {
     public void onInitialize() {
         if (BlueLibCommon.isDeveloperMode() && BlueLibCommon.PLATFORM.isModLoaded("geckolib") && BlueLibConstants.isExampleEnabled) {
             ModEntities.initializeEntities();
-            registerEventListeners();
+            registerModEventListeners();
             FabricDefaultAttributeRegistry.register(ModEntities.EXAMPLE_ONE, DragonEntity.createMobAttributes());
             FabricDefaultAttributeRegistry.register(ModEntities.EXAMPLE_TWO, RexEntity.createMobAttributes());
         }
+        registerEventListeners();
         ClientTickEvents.END_CLIENT_TICK.register(client -> {
             if (!hasInitialized) {
                 hasInitialized = true;
@@ -73,13 +75,22 @@ public class BlueLib implements ModInitializer {
     }
 
     /**
-     * Registers the event listeners.
+     * Registers the Mod Dependant event listeners.
      *
      * @author MeAlam
      * @since 1.0.0
      */
-    public static void registerEventListeners() {
+    public static void registerModEventListeners() {
         ServerLifecycleEvents.SERVER_STARTING.register(ReloadHandler::onServerStart);
+    }
+
+    /**
+     * Registers the event listeners.
+     *
+     * @author MeAlam
+     * @since 1.2.0
+     */
+    public static void registerEventListeners() {
         ServerMessageEvents.ALLOW_CHAT_MESSAGE.register(ChatHandler::onAllowChat);
     }
 }


### PR DESCRIPTION
## Description
### Fixed Fabric Markdown not being Applied

### Added
* Users can now modify the Prefix/Suffix of the Markdown.
* Users can now check if a specific Markdown is enabled.
* adding `\` in front of the markdown will cancel it out.
   * ex. `\**bold**` will send \*\*bold\** in stead of **bold**.

### Changed
* If your message between the Prefix and the Suffix is empty, it will not delete the Prefix/Suffix.
   * Before if you typed \** without anything else, it would delete the ** because the code assumed that it was applying Italic Styling. 


## Changes
- **Change 1**: If your message between the Prefix and the Suffix is empty, it will not delete the Prefix/Suffix.
- **Change 2**: Users can now check if a specific Markdown is enabled.
- **Change 3**: Adding `\` in front of the markdown will cancel it out.
- **Change 4**: Users can now modify the Prefix/Suffix of the Markdown.

## How has this been tested?
* Use the Methods to modify the prefix/suffix
* Start Minecraft
* Send a Message using the old Prefix/Suffix
* Send a Message with \ in front.
* Send the Prefix/Suffix without anything in between.

## Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Documentation update

## Checklist
- [x] My code follows the style guidelines of this project. [Contributing](https://github.com/MeAlam1/BlueLib/blob/1.21/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code.
- [x] I have commented my code following the guidelines. [Contributing](https://github.com/MeAlam1/BlueLib/blob/1.21/CONTRIBUTING.md)
- [x] My changes generate no new warnings.

## Related Issues
* #61 
