### PR TITLE
Refactored the Variant Loader to a General Parser

### DIFF
--- a/common/src/main/java/software/bluelib/entity/variant/VariantLoader.java
+++ b/common/src/main/java/software/bluelib/entity/variant/VariantLoader.java
@@ -1,113 +1,27 @@
-// Copyright (c) BlueLib. Licensed under the MIT License.
-
 package software.bluelib.entity.variant;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
-import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.MinecraftServer;
-import net.minecraft.server.packs.resources.ResourceManager;
-import software.bluelib.interfaces.variant.base.IVariantEntityBase;
-import software.bluelib.json.JSONLoader;
-import software.bluelib.json.JSONMerger;
+import software.bluelib.json.JSONParser;
 import software.bluelib.utils.logging.BaseLogLevel;
 import software.bluelib.utils.logging.BaseLogger;
 import software.bluelib.utils.variant.ParameterUtils;
 
-/**
- * A {@code public class} that implements the {@link IVariantEntityBase} {@code interface} that manages the loading and storage of entity variants.
- * <p>
- * The class handles loading and merging of JSON Data by utilizing the {@link JSONLoader} and {@link JSONMerger} classes. <br>
- * To load the Variants it loops through all resources in a folder and merges them into a single {@link JsonObject}. <br>
- * The merged JSON data is then parsed into {} instances and stored in {@link #AllVariants}. <br>
- * </p>
- * Key Methods:
- * <ul>
- * <li>{@link #loadVariants(String, MinecraftServer, String)} - Loads and merges variant data by looping thru all resources in a folder.</li>
- * </ul>
- *
- * @author MeAlam
- * @version 1.4.0
- * @since 1.0.0
- */
-public class VariantLoader implements IVariantEntityBase {
+import java.util.HashMap;
+import java.util.Map;
 
-    /**
-     * A {@code public static} {@link Map} that stores all variants of an entity.
-     * <p>
-     * The field is used to store all variants of an entity and is accessed by the {@link ParameterUtils} class.
-     * </p>
-     * <br>
-     * <strong>We don't recommend using this field directly unless you know what you are doing.</strong>
-     *
-     * @since 1.3.0
-     */
-    public static Map<String, JsonObject> AllVariants = new HashMap<>();
+public class VariantLoader extends JSONParser {
+    public static final Map<String, JsonObject> AllVariants = new HashMap<>();
+    private static final VariantLoader LOADER = new VariantLoader();
 
-    /**
-     * A {@code private static final} {@link JSONLoader} to load JSON data from resources.
-     *
-     * @since 1.0.0
-     */
-    private static final JSONLoader jsonLoader = new JSONLoader();
-
-    /**
-     * A {@code private static final} {@link JSONMerger} to merge JSON data.
-     * <p>
-     * This {@link JSONMerger} instance is used to merge JSON data into a single {@link JsonObject}.
-     * </p>
-     *
-     * @since 1.0.0
-     */
-    private static final JSONMerger jsonMerger = new JSONMerger();
-
-    /**
-     * A {@code public static void} that loads and merges variant data from JSON resources in the specified folder path.
-     * <p>
-     * The method loops through all resources in the folder and merges them into a single {@link JsonObject}. <br>
-     * The merged JSON data is then parsed into {@link JsonObject} instances and stored in {@link #AllVariants}. <br>
-     * </p>
-     *
-     * @param pFolderPath {@link String} - The path to the folder containing JSON resources.
-     * @param pServer     {@link MinecraftServer} - The {@link MinecraftServer} instance used to access resources.
-     * @param pEntityName {@link String} - The name of the entity whose variants should be cleared before loading new ones.
-     * @author MeAlam
-     * @since 1.0.0
-     */
     public static void loadVariants(String pFolderPath, MinecraftServer pServer, String pEntityName) {
-        ResourceManager resourceManager = pServer.getResourceManager();
-        JsonObject mergedJsonObject = new JsonObject();
-
-        Collection<ResourceLocation> collection = resourceManager.listResources(pFolderPath, pFiles -> pFiles.getPath().endsWith(".json")).keySet();
-
-        BaseLogger.log(BaseLogLevel.INFO, "Found resources: " + collection + " at: " + pFolderPath + " for: " + pEntityName, true);
-
-        for (ResourceLocation resourceLocation : collection) {
-            try {
-                BaseLogger.log(BaseLogLevel.INFO, "Loading JSON data from resource: " + resourceLocation.toString(), true);
-                JsonObject jsonObject = jsonLoader.loadJson(resourceLocation, resourceManager);
-                jsonMerger.mergeJsonObjects(mergedJsonObject, jsonObject);
-            } catch (Exception pException) {
-                BaseLogger.log(BaseLogLevel.ERROR, "Failed to load JSON data from resource: " + resourceLocation.toString(), pException, true);
-            }
-        }
-        parseVariants(pEntityName, mergedJsonObject);
+        LOADER.loadData(pFolderPath, pServer);
+        AllVariants.putAll(LOADER.getDataMap());
+        parseVariants(pEntityName, LOADER.getMergedJsonObject());
+        BaseLogger.log(BaseLogLevel.INFO, "Variants: " + AllVariants);
     }
 
-    /**
-     * A {@code private static void} that parses the merged {@link JsonObject} containing variant data.
-     * <p>
-     * The method parses the merged {@link JsonObject} and stores the data in the {@link #AllVariants} map.
-     * The map is used to store all variants of an entity.
-     * </p>
-     *
-     * @param pJsonObject {@link JsonObject} - The merged {@link JsonObject} containing variant data.
-     * @author MeAlam
-     * @since 1.0.0
-     */
     private static void parseVariants(String pEntityName, JsonObject pJsonObject) {
         for (Map.Entry<String, JsonElement> ignored : pJsonObject.entrySet()) {
             AllVariants.putIfAbsent(pEntityName, pJsonObject);

--- a/common/src/main/java/software/bluelib/entity/variant/VariantLoader.java
+++ b/common/src/main/java/software/bluelib/entity/variant/VariantLoader.java
@@ -1,3 +1,5 @@
+// Copyright (c) BlueLib. Licensed under the MIT License.
+
 package software.bluelib.entity.variant;
 
 import com.google.gson.JsonElement;
@@ -11,17 +13,101 @@ import software.bluelib.utils.variant.ParameterUtils;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * A class for loading and managing entity variants.
+ * <p>
+ * Purpose: This class handles the loading and parsing of entity variants from JSON files.<br>
+ * When: The variants are loaded when the {@link #loadVariants(String, MinecraftServer, String)} method is called.<br>
+ * Where: The variants are stored in a static map and can be accessed globally.<br>
+ * Additional Info: This class extends {@link JSONParser} to utilize its JSON parsing capabilities.
+ * </p>
+ * Key Methods:
+ * <ul>
+ * <li>{@link #loadVariants(String, MinecraftServer, String)} - Loads variants from a specified folder path.</li>
+ * <li>{@link #parseVariants(String, JsonObject)} - Parses the loaded JSON data and stores the variants.</li>
+ * </ul>
+ *
+ * @author MeAlam
+ * @version 1.7.0
+ * @see JSONParser
+ * @see ParameterUtils
+ * @see BaseLogger
+ * @since 1.0.0
+ */
 public class VariantLoader extends JSONParser {
+    /**
+     * A map to store all loaded variants.
+     * <p>
+     * Purpose: This map holds all the variants loaded from JSON files, keyed by entity name.<br>
+     * When: Populated when the {@link #loadVariants(String, MinecraftServer, String)} method is called.<br>
+     * Where: Used globally to access the loaded variants.<br>
+     * Additional Info: The map is static to allow global access.
+     * </p>
+     *
+     * @see #loadVariants(String, MinecraftServer, String)
+     * @see #parseVariants(String, JsonObject)
+     * @since 1.3.0
+     */
     public static final Map<String, JsonObject> AllVariants = new HashMap<>();
+
+    /**
+     * A singleton instance of the VariantLoader.
+     * <p>
+     * Purpose: This instance is used to load and parse JSON data.<br>
+     * When: Initialized when the class is loaded.<br>
+     * Where: Used internally within the class methods.<br>
+     * Additional Info: Ensures only one instance of VariantLoader is used.
+     * </p>
+     *
+     * @see #loadVariants(String, MinecraftServer, String)
+     * @since 1.7.0
+     */
     private static final VariantLoader LOADER = new VariantLoader();
 
+    /**
+     * Loads variants from the specified folder path.
+     * <p>
+     * Purpose: This method loads JSON data from the specified folder path and parses the variants.<br>
+     * When: Called when variants need to be loaded for a specific entity.<br>
+     * Where: Typically invoked during server initialization or entity configuration.<br>
+     * Additional Info: The loaded variants are stored in the {@link #AllVariants} map.
+     * </p>
+     *
+     * @param pFolderPath The folder path to load JSON data from.
+     * @param pServer     The Minecraft server instance.
+     * @param pEntityName The name of the entity to load variants for.
+     * @author MeAlam
+     * @see #AllVariants
+     * @see #parseVariants(String, JsonObject)
+     * @see JSONParser#loadData(String, MinecraftServer)
+     * @see JSONParser#getDataMap()
+     * @since 1.0.0
+     */
     public static void loadVariants(String pFolderPath, MinecraftServer pServer, String pEntityName) {
         LOADER.loadData(pFolderPath, pServer);
         AllVariants.putAll(LOADER.getDataMap());
         parseVariants(pEntityName, LOADER.getMergedJsonObject());
-        BaseLogger.log(BaseLogLevel.INFO, "Variants: " + AllVariants);
+        BaseLogger.log(BaseLogLevel.INFO, "All data of Variants: " + AllVariants, true);
     }
 
+    /**
+     * Parses the loaded JSON data and stores the variants.
+     * <p>
+     * Purpose: This method parses the JSON data and stores the variants in the {@link #AllVariants} map.<br>
+     * When: Called internally after loading the JSON data.<br>
+     * Where: Invoked within the {@link #loadVariants(String, MinecraftServer, String)} method.<br>
+     * Additional Info: The parsed variants are logged for debugging purposes.
+     * </p>
+     *
+     * @param pEntityName The name of the entity to parse variants for.
+     * @param pJsonObject The JSON object containing the variant data.
+     * @author MeAlam
+     * @see #AllVariants
+     * @see #loadVariants(String, MinecraftServer, String)
+     * @see ParameterUtils#getAllEntities()
+     * @see ParameterUtils#getVariantsOfEntity(String)
+     * @since 1.0.0
+     */
     private static void parseVariants(String pEntityName, JsonObject pJsonObject) {
         for (Map.Entry<String, JsonElement> ignored : pJsonObject.entrySet()) {
             AllVariants.putIfAbsent(pEntityName, pJsonObject);

--- a/common/src/main/java/software/bluelib/entity/variant/VariantLoader.java
+++ b/common/src/main/java/software/bluelib/entity/variant/VariantLoader.java
@@ -4,14 +4,13 @@ package software.bluelib.entity.variant;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import java.util.HashMap;
+import java.util.Map;
 import net.minecraft.server.MinecraftServer;
 import software.bluelib.json.JSONParser;
 import software.bluelib.utils.logging.BaseLogLevel;
 import software.bluelib.utils.logging.BaseLogger;
 import software.bluelib.utils.variant.ParameterUtils;
-
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * A class for loading and managing entity variants.
@@ -35,6 +34,7 @@ import java.util.Map;
  * @since 1.0.0
  */
 public class VariantLoader extends JSONParser {
+
     /**
      * A map to store all loaded variants.
      * <p>

--- a/common/src/main/java/software/bluelib/json/JSONParser.java
+++ b/common/src/main/java/software/bluelib/json/JSONParser.java
@@ -3,15 +3,14 @@
 package software.bluelib.json;
 
 import com.google.gson.JsonObject;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.packs.resources.ResourceManager;
 import software.bluelib.utils.logging.BaseLogLevel;
 import software.bluelib.utils.logging.BaseLogger;
-
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * An abstract class for parsing JSON data.
@@ -40,6 +39,7 @@ import java.util.Map;
  * @author MeAlam
  */
 public abstract class JSONParser {
+
     /**
      * A map to store JSON data with their corresponding keys.
      * <p>
@@ -104,7 +104,7 @@ public abstract class JSONParser {
      * </p>
      *
      * @param pFolderPath The folder path to load JSON data from.
-     * @param pServer The Minecraft server instance.
+     * @param pServer     The Minecraft server instance.
      * @since 1.7.0
      * @author MeAlam
      * @see JSONLoader
@@ -119,18 +119,17 @@ public abstract class JSONParser {
         ResourceManager resourceManager = pServer.getResourceManager();
         mergedJsonObject = new JsonObject();
 
-        Collection<ResourceLocation> resources =
-                resourceManager.listResources(pFolderPath, path -> path.getPath().endsWith(".json")).keySet();
+        Collection<ResourceLocation> resources = resourceManager.listResources(pFolderPath, path -> path.getPath().endsWith(".json")).keySet();
 
-        BaseLogger.log(BaseLogLevel.INFO, "Found resources: " + resources + " at: " + pFolderPath);
+        BaseLogger.log(BaseLogLevel.INFO, "Found resources: " + resources + " at: " + pFolderPath, true);
 
         for (ResourceLocation resourceLocation : resources) {
             try {
-                BaseLogger.log(BaseLogLevel.INFO, "Loading JSON data from resource: " + resourceLocation);
+                BaseLogger.log(BaseLogLevel.INFO, "Loading JSON data from resource: " + resourceLocation, true);
                 JsonObject jsonObject = jsonLoader.loadJson(resourceLocation, resourceManager);
                 jsonMerger.mergeJsonObjects(mergedJsonObject, jsonObject);
             } catch (Exception exception) {
-                BaseLogger.log(BaseLogLevel.ERROR, "Failed to load JSON data from resource: " + resourceLocation, exception);
+                BaseLogger.log(BaseLogLevel.ERROR, "Failed to load JSON data from resource: " + resourceLocation, exception, true);
             }
         }
     }

--- a/common/src/main/java/software/bluelib/json/JSONParser.java
+++ b/common/src/main/java/software/bluelib/json/JSONParser.java
@@ -1,3 +1,5 @@
+// Copyright (c) BlueLib. Licensed under the MIT License.
+
 package software.bluelib.json;
 
 import com.google.gson.JsonObject;
@@ -11,12 +13,108 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
+/**
+ * An abstract class for parsing JSON data.
+ * <p>
+ * Purpose: This class provides methods to load and merge JSON data from specified folder paths.<br>
+ * When: The JSON data is loaded and merged when the {@link #loadData(String, MinecraftServer)} method is called.<br>
+ * Where: The JSON data is loaded from the specified folder path and merged into a single {@link JsonObject}.<br>
+ * Additional Info: This class uses {@link JSONLoader} to load JSON data and {@link JSONMerger} to merge JSON objects.
+ * </p>
+ * Key Methods:
+ * <ul>
+ * <li>{@link #loadData(String, MinecraftServer)} - Loads and merges JSON data from the specified folder path.</li>
+ * <li>{@link #getDataMap()} - Returns the data map containing JSON data.</li>
+ * <li>{@link #getMergedJsonObject()} - Returns the merged JSON object.</li>
+ * </ul>
+ *
+ * @see JSONLoader
+ * @see JSONMerger
+ * @see MinecraftServer
+ * @see JsonObject
+ * @see ResourceManager
+ * @see ResourceLocation
+ * @see Collection
+ * @since 1.7.0
+ * @version 1.7.0
+ * @author MeAlam
+ */
 public abstract class JSONParser {
+    /**
+     * A map to store JSON data with their corresponding keys.
+     * <p>
+     * Purpose: This map holds the JSON data loaded from the specified folder path.<br>
+     * When: The map is populated when the {@link #loadData(String, MinecraftServer)} method is called.<br>
+     * Where: The map is used to store JSON data with their corresponding keys.<br>
+     * Additional Info: The keys are the resource locations of the JSON files.
+     * </p>
+     *
+     * @since 1.7.0
+     */
     protected Map<String, JsonObject> dataMap = new HashMap<>();
+
+    /**
+     * A static instance of JSONLoader to load JSON data.
+     * <p>
+     * Purpose: This instance is used to load JSON data from the specified folder path.<br>
+     * When: The instance is used when the {@link #loadData(String, MinecraftServer)} method is called.<br>
+     * Where: The instance is used to load JSON data from the specified folder path.<br>
+     * Additional Info: The JSONLoader class provides methods to load JSON data from resource locations.
+     * </p>
+     *
+     * @see JSONLoader
+     * @since 1.7.0
+     */
     protected static final JSONLoader jsonLoader = new JSONLoader();
+
+    /**
+     * A static instance of JSONMerger to merge JSON objects.
+     * <p>
+     * Purpose: This instance is used to merge JSON objects loaded from the specified folder path.<br>
+     * When: The instance is used when the {@link #loadData(String, MinecraftServer)} method is called.<br>
+     * Where: The instance is used to merge JSON objects loaded from the specified folder path.<br>
+     * Additional Info: The JSONMerger class provides methods to merge JSON objects.
+     * </p>
+     *
+     * @see JSONMerger
+     * @since 1.7.0
+     */
     protected static final JSONMerger jsonMerger = new JSONMerger();
+
+    /**
+     * A JsonObject to store the merged JSON data.
+     * <p>
+     * Purpose: This object holds the merged JSON data from the specified folder path.<br>
+     * When: The object is populated when the {@link #loadData(String, MinecraftServer)} method is called.<br>
+     * Where: The object is used to store the merged JSON data.<br>
+     * Additional Info: The merged JSON data is a combination of all JSON files loaded from the specified folder path.
+     * </p>
+     *
+     * @since 1.7.0
+     */
     protected JsonObject mergedJsonObject;
 
+    /**
+     * Loads JSON data from the specified folder path and merges them.
+     * <p>
+     * Purpose: This method loads JSON data from the specified folder path and merges them into a single {@link JsonObject}.<br>
+     * When: The method is called to load and merge JSON data.<br>
+     * Where: The method is called whenever JSON data needs to be loaded and merged.<br>
+     * Additional Info: The method uses {@link JSONLoader} to load JSON data and {@link JSONMerger} to merge JSON objects.
+     * </p>
+     *
+     * @param pFolderPath The folder path to load JSON data from.
+     * @param pServer The Minecraft server instance.
+     * @since 1.7.0
+     * @author MeAlam
+     * @see JSONLoader
+     * @see JSONMerger
+     * @see MinecraftServer
+     * @see JsonObject
+     * @see ResourceManager
+     * @see ResourceLocation
+     * @see Collection
+     */
     public void loadData(String pFolderPath, MinecraftServer pServer) {
         ResourceManager resourceManager = pServer.getResourceManager();
         mergedJsonObject = new JsonObject();
@@ -37,10 +135,39 @@ public abstract class JSONParser {
         }
     }
 
+    /**
+     * Returns the data map containing JSON data.
+     * <p>
+     * Purpose: This method returns the data map containing JSON data loaded from the specified folder path.<br>
+     * When: The method is called to retrieve the data map.<br>
+     * Where: The method is called from any class or method.<br>
+     * Additional Info: The data map contains JSON data with their corresponding keys.
+     * </p>
+     *
+     * @return The data map.
+     * @since 1.7.0
+     * @author MeAlam
+     * @see JsonObject
+     * @see Map
+     */
     public Map<String, JsonObject> getDataMap() {
         return dataMap;
     }
 
+    /**
+     * Returns the merged JSON object.
+     * <p>
+     * Purpose: This method returns the merged JSON object containing data from all JSON files loaded from the specified folder path.<br>
+     * When: The method is called to retrieve the merged JSON object.<br>
+     * Where: The method is called from any class or method.<br>
+     * Additional Info: The merged JSON object is a combination of all JSON files loaded from the specified folder path.
+     * </p>
+     *
+     * @return The merged JSON object.
+     * @since 1.7.0
+     * @author MeAlam
+     * @see JsonObject
+     */
     public JsonObject getMergedJsonObject() {
         return mergedJsonObject;
     }

--- a/common/src/main/java/software/bluelib/json/JSONParser.java
+++ b/common/src/main/java/software/bluelib/json/JSONParser.java
@@ -1,0 +1,47 @@
+package software.bluelib.json;
+
+import com.google.gson.JsonObject;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.packs.resources.ResourceManager;
+import software.bluelib.utils.logging.BaseLogLevel;
+import software.bluelib.utils.logging.BaseLogger;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+public abstract class JSONParser {
+    protected Map<String, JsonObject> dataMap = new HashMap<>();
+    protected static final JSONLoader jsonLoader = new JSONLoader();
+    protected static final JSONMerger jsonMerger = new JSONMerger();
+    protected JsonObject mergedJsonObject;
+
+    public void loadData(String pFolderPath, MinecraftServer pServer) {
+        ResourceManager resourceManager = pServer.getResourceManager();
+        mergedJsonObject = new JsonObject();
+
+        Collection<ResourceLocation> resources =
+                resourceManager.listResources(pFolderPath, path -> path.getPath().endsWith(".json")).keySet();
+
+        BaseLogger.log(BaseLogLevel.INFO, "Found resources: " + resources + " at: " + pFolderPath);
+
+        for (ResourceLocation resourceLocation : resources) {
+            try {
+                BaseLogger.log(BaseLogLevel.INFO, "Loading JSON data from resource: " + resourceLocation);
+                JsonObject jsonObject = jsonLoader.loadJson(resourceLocation, resourceManager);
+                jsonMerger.mergeJsonObjects(mergedJsonObject, jsonObject);
+            } catch (Exception exception) {
+                BaseLogger.log(BaseLogLevel.ERROR, "Failed to load JSON data from resource: " + resourceLocation, exception);
+            }
+        }
+    }
+
+    public Map<String, JsonObject> getDataMap() {
+        return dataMap;
+    }
+
+    public JsonObject getMergedJsonObject() {
+        return mergedJsonObject;
+    }
+}


### PR DESCRIPTION
## Description
Refactored the Variant Loader to use a general JSON parser. The parser is now designed to work independently, allowing users to parse and load custom JSON files outside of variants. This improves modularity and reusability across various components.

## Changes
- **Change 1**: Extracted the JSON parsing logic into a standalone general parser.
- **Change 2**: Updated the Variant Loader to use the general JSON parser for loading variant data.
- **Change 3**: Added support for external custom JSONs, allowing users to define and load their own JSON structures.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [x] Cleanup
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] My code follows the style guidelines of this project. [[Contributing](https://github.com/MeAlam1/BlueLib/blob/1.21/CONTRIBUTING.md)](https://github.com/MeAlam1/BlueLib/blob/1.21/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code.
- [x] I have commented my code following the guidelines. [[Contributing](https://github.com/MeAlam1/BlueLib/blob/1.21/CONTRIBUTING.md)](https://github.com/MeAlam1/BlueLib/blob/1.21/CONTRIBUTING.md)
- [x] My changes generate no new warnings.


