### PR TITLE
Added Gradients

### DIFF
--- a/common/src/main/java/software/bluelib/markdown/syntax/Color.java
+++ b/common/src/main/java/software/bluelib/markdown/syntax/Color.java
@@ -2,6 +2,9 @@
 
 package software.bluelib.markdown.syntax;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import net.minecraft.network.chat.Component;
 import net.minecraft.network.chat.MutableComponent;
@@ -26,7 +29,9 @@ import software.bluelib.utils.logging.BaseLogger;
  * <li>{@link #apply(MutableComponent)} - Applies the color feature to a given component.</li>
  * <li>{@link #processComponentTextWithColors(String, Style, MutableComponent, Pattern)} - Processes text with color formatting.</li>
  * <li>{@link #processSiblingsWithColors(MutableComponent, Pattern)} - Processes siblings with color formatting.</li>
- * <li>{@link #appendColor(String, String, Style, MutableComponent)} - Appends color formatted text to a component.</li>
+ * <li>{@link #appendColor(String, List, Style, MutableComponent)} - Appends color formatted text to a component.</li>
+ * <li>{@link #interpolateColor(int, int, float)} - Interpolates a color between two colors.</li>
+ * <li>{@link #extractColorsFromMatcher(Matcher)} - Extracts colors from a matcher.</li>
  * <li>{@link #isFeatureEnabled()} - Checks if the feature is enabled.</li>
  * <li>{@link #getFeatureName()} - Gets the name of the feature.</li>
  * <li>{@link #setPrefixSuffix(String, String)} - Sets the prefix and suffix for color formatting.</li>
@@ -125,7 +130,9 @@ public class Color extends MarkdownFeature {
             return pComponent;
         }
 
-        Pattern pattern = Pattern.compile(Pattern.quote(getPrefix()) + "(#[0-9A-Fa-f]{6})" + Pattern.quote(getSuffix()) + "\\((.*?)\\)");
+        Pattern pattern = Pattern.compile(Pattern.quote(getPrefix()) +
+                "#([0-9A-Fa-f]{6}(?:,#([0-9A-Fa-f]{6}))*)" +
+                Pattern.quote(getSuffix()) + "\\((.*?)\\)");
 
         MutableComponent result = Component.empty();
 
@@ -162,12 +169,41 @@ public class Color extends MarkdownFeature {
     protected void processComponentTextWithColors(String pText, Style pOriginalStyle, MutableComponent pResult, Pattern pPattern) {
         processComponentText(pText, pOriginalStyle, pResult, pPattern,
                 (matcher, res) -> {
-                    String color = matcher.group(1);
-                    String colorText = matcher.group(2);
-                    if (color != null && !color.isEmpty()) {
-                        appendColor(colorText, color, pOriginalStyle, res);
-                    }
+                    List<Integer> colors = extractColorsFromMatcher(matcher);
+                    String gradientText = matcher.group(matcher.groupCount());
+
+                    appendColor(gradientText, colors, pOriginalStyle, res);
                 });
+    }
+
+    /**
+     * Extracts colors from a matcher.
+     * <p>
+     * Purpose: This method extracts colors from a matcher and returns them as a list of integers.<br>
+     * When: It is called to extract colors from a matcher.<br>
+     * Where: It is invoked in {@link #processComponentTextWithColors} to extract colors from a matcher.<br>
+     * Additional Info: The method ensures that only valid colors are extracted and converted to hexadecimal format.<br>
+     * </p>
+     *
+     * @param matcher The matcher to extract colors from.
+     * @return A list of integers representing the extracted colors in hexadecimal format.
+     * @see #processComponentTextWithColors
+     * @since 1.7.0
+     */
+    private List<Integer> extractColorsFromMatcher(Matcher matcher) {
+        List<Integer> colors = new ArrayList<>();
+
+        String colorGroup = matcher.group(1);
+        String[] colorArray = colorGroup.split(",");
+        for (String color : colorArray) {
+            if (IsValidUtils.isValidColor(color)) {
+                colors.add(ColorConversionUtils.parseColorToHexString(color));
+            }
+        }
+
+        System.out.println("Colors: " + colors);
+
+        return colors;
     }
 
     /**
@@ -179,8 +215,8 @@ public class Color extends MarkdownFeature {
      * Additional Info: The method ensures that the appropriate style is applied to the appended text.<br>
      * </p>
      *
-     * @param colorText      The text to be appended.
-     * @param pColor         The color to be applied to the text.
+     * @param pColorText     The text to be appended.
+     * @param pColors        List of all colors that will be applied to the text.
      * @param pOriginalStyle The original style of the component.
      * @param pResult        The component to append the formatted text to.
      * @author MeAlam
@@ -192,13 +228,72 @@ public class Color extends MarkdownFeature {
      * @see TextColor#fromRgb(int)
      * @since 1.6.0
      */
-    private void appendColor(String colorText, String pColor, Style pOriginalStyle, MutableComponent pResult) {
-        if (IsValidUtils.isValidColor(pColor)) {
-            pResult.append(Component.literal(colorText)
-                    .setStyle(pOriginalStyle.withColor(TextColor.fromRgb(ColorConversionUtils.parseColorToHexString(pColor)))));
-        } else {
-            pResult.append(Component.literal(colorText).setStyle(pOriginalStyle));
+    private void appendColor(String pColorText, List<Integer> pColors, Style pOriginalStyle, MutableComponent pResult) {
+        if (pColors.isEmpty()) {
+            pResult.append(Component.literal(pColorText).setStyle(pOriginalStyle));
+            return;
         }
+
+        if (pColors.size() == 1) {
+            int color = pColors.get(0);
+            pResult.append(Component.literal(pColorText).setStyle(pOriginalStyle.withColor(TextColor.fromRgb(color))));
+            return;
+        }
+
+        char[] characters = pColorText.toCharArray();
+        int textLength = characters.length;
+        int colorCount = pColors.size();
+        int segmentLength = textLength / (colorCount - 1);
+        int remainder = textLength % (colorCount - 1);
+
+        int charIndex = 0;
+
+        for (int colorIndex = 0; colorIndex < colorCount - 1; colorIndex++) {
+            int startColor = pColors.get(colorIndex);
+            int endColor = pColors.get(colorIndex + 1);
+
+            int currentSegmentLength = segmentLength + (colorIndex < remainder ? 1 : 0);
+
+            for (int i = 0; i < currentSegmentLength && charIndex < textLength; i++, charIndex++) {
+                float positionRatio = (float) i / (currentSegmentLength - 1);
+                int interpolatedColor = interpolateColor(startColor, endColor, positionRatio);
+
+                pResult.append(Component.literal(String.valueOf(characters[charIndex]))
+                        .setStyle(pOriginalStyle.withColor(TextColor.fromRgb(interpolatedColor))));
+            }
+        }
+    }
+
+    /**
+     * Interpolates a color between two colors.
+     * <p>
+     * Purpose: This method interpolates a color between two colors based on a given ratio.<br>
+     * When: It is called to interpolate a color between two colors.<br>
+     * Where: It is invoked in {@link #appendColor} to interpolate a color between two colors.<br>
+     * Additional Info: The method calculates the interpolated color based on the start and end colors and the given ratio.<br>
+     * </p>
+     *
+     * @param startColor The starting color.
+     * @param endColor   The ending color.
+     * @param ratio      The ratio used to interpolate the color.
+     * @return The interpolated color between the start and end colors based on the ratio.
+     * @see #appendColor
+     * @since 1.6.0
+     */
+    private int interpolateColor(int startColor, int endColor, float ratio) {
+        int startR = (startColor >> 16) & 0xFF;
+        int startG = (startColor >> 8) & 0xFF;
+        int startB = startColor & 0xFF;
+
+        int endR = (endColor >> 16) & 0xFF;
+        int endG = (endColor >> 8) & 0xFF;
+        int endB = endColor & 0xFF;
+
+        int r = (int) (startR + (endR - startR) * ratio);
+        int g = (int) (startG + (endG - startG) * ratio);
+        int b = (int) (startB + (endB - startB) * ratio);
+
+        return (r << 16) | (g << 8) | b;
     }
 
     /**

--- a/common/src/main/java/software/bluelib/test/markdown/Markdown.java
+++ b/common/src/main/java/software/bluelib/test/markdown/Markdown.java
@@ -17,6 +17,7 @@ public class Markdown {
             BoldTest.boldHyperlink(pHelper);
             BoldTest.boldColor(pHelper);
             BoldTest.boldSpoiler(pHelper);
+            BoldTest.boldGradient(pHelper);
             BoldTest.boldCancel(pHelper);
         });
     }
@@ -32,6 +33,7 @@ public class Markdown {
             ItalicTest.italicHyperlink(pHelper);
             ItalicTest.italicColor(pHelper);
             ItalicTest.italicSpoiler(pHelper);
+            ItalicTest.italicGradient(pHelper);
             ItalicTest.italicCancel(pHelper);
         });
     }
@@ -47,6 +49,7 @@ public class Markdown {
             UnderlineTest.underlineHyperlink(pHelper);
             UnderlineTest.underlineColor(pHelper);
             UnderlineTest.underlineSpoiler(pHelper);
+            UnderlineTest.underlineGradient(pHelper);
             UnderlineTest.underlineCancel(pHelper);
         });
     }
@@ -62,6 +65,7 @@ public class Markdown {
             StrikethroughTest.strikethroughHyperlink(pHelper);
             StrikethroughTest.strikethroughColor(pHelper);
             StrikethroughTest.strikethroughSpoiler(pHelper);
+            StrikethroughTest.strikethroughGradient(pHelper);
             StrikethroughTest.strikethroughCancel(pHelper);
         });
     }
@@ -77,6 +81,7 @@ public class Markdown {
             HyperlinkTest.hyperlinkHyperlink(pHelper);
             HyperlinkTest.hyperlinkColor(pHelper);
             HyperlinkTest.hyperlinkSpoiler(pHelper);
+            HyperlinkTest.hyperlinkGradient(pHelper);
             HyperlinkTest.hyperlinkCancel(pHelper);
             HyperlinkTest.hyperlinkInvalid(pHelper);
         });
@@ -93,6 +98,7 @@ public class Markdown {
             ColorTest.colorHyperlink(pHelper);
             ColorTest.colorColor(pHelper);
             ColorTest.colorSpoiler(pHelper);
+            ColorTest.colorGradient(pHelper);
             ColorTest.colorCancel(pHelper);
             ColorTest.colorInvalid(pHelper);
         });
@@ -109,7 +115,24 @@ public class Markdown {
             SpoilerTest.spoilerHyperlink(pHelper);
             SpoilerTest.spoilerColor(pHelper);
             SpoilerTest.spoilerSpoiler(pHelper);
+            SpoilerTest.spoilerGradient(pHelper);
             SpoilerTest.spoilerCancel(pHelper);
+        });
+    }
+
+    @GameTest
+    public static void gradient(GameTestHelper pHelper) {
+        pHelper.succeedIf(() -> {
+            GradientTest.gradient(pHelper);
+            GradientTest.gradientBold(pHelper);
+            GradientTest.gradientItalic(pHelper);
+            GradientTest.gradientUnderline(pHelper);
+            GradientTest.gradientStrikethrough(pHelper);
+            GradientTest.gradientHyperlink(pHelper);
+            GradientTest.gradientColor(pHelper);
+            GradientTest.gradientSpoiler(pHelper);
+            GradientTest.gradientGradient(pHelper);
+            GradientTest.gradientCancel(pHelper);
         });
     }
 

--- a/common/src/main/java/software/bluelib/test/markdown/MarkdownStyleTest.java
+++ b/common/src/main/java/software/bluelib/test/markdown/MarkdownStyleTest.java
@@ -21,7 +21,9 @@ public class MarkdownStyleTest {
             "-#" + MessageUtils.getRandomHex() + "-(Color)", // Color
             "\\-#" + MessageUtils.getRandomHex() + "-(Color)", // Color Canceled
             "||Spoiler||", // Spoiler
-            "\\||Spoiler||" // Spoiler Canceled
+            "\\||Spoiler||", // Spoiler Canceled
+            "-#" + MessageUtils.getRandomHex() + ",#" + MessageUtils.getRandomHex() + ",#" + MessageUtils.getRandomHex() + "-(Gradient)", // Gradient
+            "\\-#" + MessageUtils.getRandomHex() + ",#" + MessageUtils.getRandomHex() + ",#" + MessageUtils.getRandomHex() + "-(Gradient)" // Gradient Canceled
     );
 
     private static final List<String> CANCEL_ONLY_STYLES = List.of(
@@ -31,7 +33,8 @@ public class MarkdownStyleTest {
             "\\~~Strikethrough~~", // Strikethrough Canceled
             "\\[Hyperlink](https://modrinth.com/mod/bluelib)", // Hyperlink Canceled
             "\\-#" + MessageUtils.getRandomHex() + "-(Color)", // Color Canceled
-            "\\||Spoiler||" // Spoiler Canceled
+            "\\||Spoiler||", // Spoiler Canceled
+            "\\-#" + MessageUtils.getRandomHex() + ",#" + MessageUtils.getRandomHex() + ",#" + MessageUtils.getRandomHex() + "-(Gradient)" // Gradient Canceled
     );
 
     private static final List<String> ALL_TEST_STYLES = List.of(
@@ -41,7 +44,8 @@ public class MarkdownStyleTest {
             "~~Strikethrough~~", // Strikethrough
             "[Hyperlink](https://www.curseforge.com/minecraft/mc-mods/bluelib)", // Hyperlink
             "-#" + MessageUtils.getRandomHex() + "-(Color)", // Color
-            "||Spoiler||" // Spoiler
+            "||Spoiler||", // Spoiler
+            "-#" + MessageUtils.getRandomHex() + ",#" + MessageUtils.getRandomHex() + ",#" + MessageUtils.getRandomHex() + "-(Gradient)" // Gradient
     );
 
     private static final List<String> ALL_TWICE_STYLES = List.of(
@@ -58,7 +62,9 @@ public class MarkdownStyleTest {
             "-#" + MessageUtils.getRandomHex() + "-(Color)", // Color
             "-#" + MessageUtils.getRandomHex() + "-(Color)", // Color
             "||Spoiler||", // Spoiler
-            "||Spoiler||" // Spoiler
+            "||Spoiler||", // Spoiler
+            "-#" + MessageUtils.getRandomHex() + ",#" + MessageUtils.getRandomHex() + ",#" + MessageUtils.getRandomHex() + "-(Gradient)", // Gradient
+            "-#" + MessageUtils.getRandomHex() + ",#" + MessageUtils.getRandomHex() + ",#" + MessageUtils.getRandomHex() + "-(Gradient)" // Gradient
     );
 
     public static void testAllStyles(GameTestHelper pHelper) {

--- a/common/src/main/java/software/bluelib/test/markdown/syntax/BoldTest.java
+++ b/common/src/main/java/software/bluelib/test/markdown/syntax/BoldTest.java
@@ -37,6 +37,10 @@ public class BoldTest {
         MessageUtils.sendMessageToPlayers(pHelper, "§6 This is a bold/spoiler test: §r **bold** ||spoiler||");
     }
 
+    public static void boldGradient(GameTestHelper pHelper) {
+        MessageUtils.sendMessageToPlayers(pHelper, "§6 This is a bold/gradient test: §r **bold** -#" + MessageUtils.getRandomHex() + ",#" + MessageUtils.getRandomHex() + ",#" + MessageUtils.getRandomHex() + "-(Gradient)");
+    }
+
     public static void boldCancel(GameTestHelper pHelper) {
         MessageUtils.sendMessageToPlayers(pHelper, "§6 This is a canceled bold test: §r \\**bold**");
     }

--- a/common/src/main/java/software/bluelib/test/markdown/syntax/ColorTest.java
+++ b/common/src/main/java/software/bluelib/test/markdown/syntax/ColorTest.java
@@ -37,6 +37,10 @@ public class ColorTest {
         MessageUtils.sendMessageToPlayers(pHelper, "§6 This is a color/spoiler test: §r -#" + MessageUtils.getRandomHex() + "-(Color) ||spoiler||");
     }
 
+    public static void colorGradient(GameTestHelper pHelper) {
+        MessageUtils.sendMessageToPlayers(pHelper, "§6 This is a color/gradient test: §r -#" + MessageUtils.getRandomHex() + "-(Color) -#" + MessageUtils.getRandomHex() + ",#" + MessageUtils.getRandomHex() + ",#" + MessageUtils.getRandomHex() + "-(Gradient)");
+    }
+
     public static void colorCancel(GameTestHelper pHelper) {
         MessageUtils.sendMessageToPlayers(pHelper, "§6 This is a canceled color test: §r \\-#" + MessageUtils.getRandomHex() + "-(Color)");
     }

--- a/common/src/main/java/software/bluelib/test/markdown/syntax/GradientTest.java
+++ b/common/src/main/java/software/bluelib/test/markdown/syntax/GradientTest.java
@@ -1,0 +1,51 @@
+package software.bluelib.test.markdown.syntax;
+
+import net.minecraft.gametest.framework.GameTestHelper;
+import software.bluelib.test.utils.MessageUtils;
+
+public class GradientTest {
+
+    public static void gradient(GameTestHelper pHelper) {
+        MessageUtils.sendMessageToPlayers(pHelper, "§6 This is a gradient test: §r -#" + MessageUtils.getRandomHex() + ",#" + MessageUtils.getRandomHex() + ",#" + MessageUtils.getRandomHex() + ",#" + MessageUtils.getRandomHex() + ",#" + MessageUtils.getRandomHex() + "-(Gradient)");
+    }
+
+    public static void gradientBold(GameTestHelper pHelper) {
+        MessageUtils.sendMessageToPlayers(pHelper, "§6 This is a gradient/bold test: §r -#" + MessageUtils.getRandomHex() + ",#" + MessageUtils.getRandomHex() + ",#" + MessageUtils.getRandomHex() + "-(Gradient) **bold**");
+    }
+
+    public static void gradientItalic(GameTestHelper pHelper) {
+        MessageUtils.sendMessageToPlayers(pHelper, "§6 This is a gradient/italic test: §r -#" + MessageUtils.getRandomHex() + ",#" + MessageUtils.getRandomHex() + ",#" + MessageUtils.getRandomHex() + "-(Gradient) *italic*");
+    }
+
+    public static void gradientUnderline(GameTestHelper pHelper) {
+        MessageUtils.sendMessageToPlayers(pHelper, "§6 This is a gradient/underline test: §r -#" + MessageUtils.getRandomHex() + ",#" + MessageUtils.getRandomHex() + ",#" + MessageUtils.getRandomHex() + "-(Gradient) __Underline__");
+    }
+
+    public static void gradientStrikethrough(GameTestHelper pHelper) {
+        MessageUtils.sendMessageToPlayers(pHelper, "§6 This is a gradient/strikethrough test: §r -#" + MessageUtils.getRandomHex() + ",#" + MessageUtils.getRandomHex() + ",#" + MessageUtils.getRandomHex() + "-(Gradient) ~~Strikethrough~~");
+    }
+
+    public static void gradientHyperlink(GameTestHelper pHelper) {
+        MessageUtils.sendMessageToPlayers(pHelper, "§6 This is a gradient/hyperlink test: §r -#" + MessageUtils.getRandomHex() + ",#" + MessageUtils.getRandomHex() + ",#" + MessageUtils.getRandomHex() + "-(Gradient) [Hyperlink](https://www.curseforge.com/minecraft/mc-mods/bluelib)");
+    }
+
+    public static void gradientColor(GameTestHelper pHelper) {
+        MessageUtils.sendMessageToPlayers(pHelper, "§6 This is a gradient/color test: §r -#" + MessageUtils.getRandomHex() + ",#" + MessageUtils.getRandomHex() + ",#" + MessageUtils.getRandomHex() + "-(Gradient) -#" + MessageUtils.getRandomHex() + "-(color)");
+    }
+
+    public static void gradientSpoiler(GameTestHelper pHelper) {
+        MessageUtils.sendMessageToPlayers(pHelper, "§6 This is a gradient/spoiler test: §r -#" + MessageUtils.getRandomHex() + ",#" + MessageUtils.getRandomHex() + ",#" + MessageUtils.getRandomHex() + "-(Gradient) ||spoiler||");
+    }
+
+    public static void gradientGradient(GameTestHelper pHelper) {
+        MessageUtils.sendMessageToPlayers(pHelper, "§6 This is a gradient/gradient test: §r -#" + MessageUtils.getRandomHex() + ",#" + MessageUtils.getRandomHex() + ",#" + MessageUtils.getRandomHex() + "-(Gradient) -#" + MessageUtils.getRandomHex() + ",#" + MessageUtils.getRandomHex() + ",#" + MessageUtils.getRandomHex() + "-(Gradient)");
+    }
+
+    public static void gradientCancel(GameTestHelper pHelper) {
+        MessageUtils.sendMessageToPlayers(pHelper, "§6 This is a canceled gradient test: §r \\-#" + MessageUtils.getRandomHex() + ",#" + MessageUtils.getRandomHex() + ",#" + MessageUtils.getRandomHex() + "-(Gradient)");
+    }
+
+    public static void gradientInvalid(GameTestHelper pHelper) {
+        MessageUtils.sendMessageToPlayers(pHelper, "§6 This is an invalid gradient test: §r -#invalidgradient-(gradient)");
+    }
+}

--- a/common/src/main/java/software/bluelib/test/markdown/syntax/HyperlinkTest.java
+++ b/common/src/main/java/software/bluelib/test/markdown/syntax/HyperlinkTest.java
@@ -37,6 +37,10 @@ public class HyperlinkTest {
         MessageUtils.sendMessageToPlayers(pHelper, "§6 This is a hyperlink/spoiler test: §r [Hyperlink](https://github.com/MeAlam1/BlueLib/issues) ||spoiler||");
     }
 
+    public static void hyperlinkGradient(GameTestHelper pHelper) {
+        MessageUtils.sendMessageToPlayers(pHelper, "§6 This is a hyperlink/gradient test: §r [Hyperlink](https://www.curseforge.com/minecraft/mc-mods/bluelib) -#" + MessageUtils.getRandomHex() + ",#" + MessageUtils.getRandomHex() + ",#" + MessageUtils.getRandomHex() + "-(Gradient)");
+    }
+
     public static void hyperlinkCancel(GameTestHelper pHelper) {
         MessageUtils.sendMessageToPlayers(pHelper, "§6 This is a canceled hyperlink test: §r \\[Hyperlink](https://www.curseforge.com/minecraft/mc-mods/bluelib)");
     }

--- a/common/src/main/java/software/bluelib/test/markdown/syntax/ItalicTest.java
+++ b/common/src/main/java/software/bluelib/test/markdown/syntax/ItalicTest.java
@@ -37,6 +37,10 @@ public class ItalicTest {
         MessageUtils.sendMessageToPlayers(pHelper, "§6 This is a italic/spoiler test: §r *italic* ||spoiler||");
     }
 
+    public static void italicGradient(GameTestHelper pHelper) {
+        MessageUtils.sendMessageToPlayers(pHelper, "§6 This is an italic/gradient test: §r *italic* -#" + MessageUtils.getRandomHex() + ",#" + MessageUtils.getRandomHex() + ",#" + MessageUtils.getRandomHex() + "-(Gradient)");
+    }
+
     public static void italicCancel(GameTestHelper pHelper) {
         MessageUtils.sendMessageToPlayers(pHelper, "§6 This is an canceled italic test: §r \\*italic*");
     }

--- a/common/src/main/java/software/bluelib/test/markdown/syntax/SpoilerTest.java
+++ b/common/src/main/java/software/bluelib/test/markdown/syntax/SpoilerTest.java
@@ -37,6 +37,10 @@ public class SpoilerTest {
         MessageUtils.sendMessageToPlayers(pHelper, "§6 This is a spoiler/spoiler test: §r ||spoiler|| ||spoiler||");
     }
 
+    public static void spoilerGradient(GameTestHelper pHelper) {
+        MessageUtils.sendMessageToPlayers(pHelper, "§6 This is a spoiler/gradient test: §r ||spoiler|| -#" + MessageUtils.getRandomHex() + ",#" + MessageUtils.getRandomHex() + ",#" + MessageUtils.getRandomHex() + +MessageUtils.getRandomHex() + "-(Gradient)");
+    }
+
     public static void spoilerCancel(GameTestHelper pHelper) {
         MessageUtils.sendMessageToPlayers(pHelper, "§6 This is a canceled spoiler test: §r \\||spoiler||");
     }

--- a/common/src/main/java/software/bluelib/test/markdown/syntax/StrikethroughTest.java
+++ b/common/src/main/java/software/bluelib/test/markdown/syntax/StrikethroughTest.java
@@ -37,6 +37,10 @@ public class StrikethroughTest {
         MessageUtils.sendMessageToPlayers(pHelper, "§6 This is a strikethrough/spoiler test: §r ~~Strikethrough~~ ||spoiler||");
     }
 
+    public static void strikethroughGradient(GameTestHelper pHelper) {
+        MessageUtils.sendMessageToPlayers(pHelper, "§6 This is a strikethrough/gradient test: §r ~~Strikethrough~~ -#" + MessageUtils.getRandomHex() + ",#" + MessageUtils.getRandomHex() + ",#" + MessageUtils.getRandomHex() + "-(Gradient)");
+    }
+
     public static void strikethroughCancel(GameTestHelper pHelper) {
         MessageUtils.sendMessageToPlayers(pHelper, "§6 This is a canceled strikethrough test: §r \\~~Strikethrough~~");
     }

--- a/common/src/main/java/software/bluelib/test/markdown/syntax/UnderlineTest.java
+++ b/common/src/main/java/software/bluelib/test/markdown/syntax/UnderlineTest.java
@@ -37,6 +37,10 @@ public class UnderlineTest {
         MessageUtils.sendMessageToPlayers(pHelper, "§6 This is a underline/spoiler test: §r __Underline__ ||spoiler||");
     }
 
+    public static void underlineGradient(GameTestHelper pHelper) {
+        MessageUtils.sendMessageToPlayers(pHelper, "§6 This is a underline/gradient test: §r __Underline__ -#" + MessageUtils.getRandomHex() + ",#" + MessageUtils.getRandomHex() + ",#" + MessageUtils.getRandomHex() + "-(Gradient)");
+    }
+
     public static void underlineCancel(GameTestHelper pHelper) {
         MessageUtils.sendMessageToPlayers(pHelper, "§6 This is a canceled underline test: §r \\__Underline__");
     }


### PR DESCRIPTION
## Description
Expanded the Color markdown by adding Gradients!

Users can apply gradients by using
-#hex1,#hex2,#hex3-(text)
aka
-#000000,#FFFFFF,#0000FF-(this message goes from Black to White to Blue)

## Changes
- **Change 1**: Added Gradiants
- **Change 2**: Added Respective Test Cases
- 
## How has this been tested?
I wrote Automated Tests in the `Test` Package and i have run them all

## Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/72b47d53-3b8f-4c73-bf7d-140ac39e3cd7)

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Cleanup
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] My code follows the style guidelines of this project. [Contributing](https://github.com/MeAlam1/BlueLib/blob/1.21/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code.
- [x] I have commented my code following the guidelines. [Contributing](https://github.com/MeAlam1/BlueLib/blob/1.21/CONTRIBUTING.md)
- [x] My changes generate no new warnings.

## Related Issues
#61 
