### PR TITLE
Fixed /reload on Fabric

### DIFF
--- a/fabric/src/main/java/software/bluelib/BlueLib.java
+++ b/fabric/src/main/java/software/bluelib/BlueLib.java
@@ -23,7 +23,7 @@ import software.bluelib.test.TestRegistry;
  * </ul>
  *
  * @author MeAlam
- * @version 1.6.0
+ * @version 1.7.0
  * @since 1.0.0
  */
 public class BlueLib implements ModInitializer {
@@ -40,10 +40,6 @@ public class BlueLib implements ModInitializer {
 
     /**
      * A {@code public void} that registers a client tick event to initialize the BlueLib mod.
-     * <p>
-     * This method checks if the mod is being run in developer mode and if the Geckolib mod is loaded. If both conditions
-     * are met, it initializes the entities and registers the event listeners for the reload handler.
-     * </p>
      * <p>
      * This method uses {@link ClientTickEvents#END_CLIENT_TICK} to register a callback that checks
      * whether the mod has already been initialized and calls {@link BlueLibCommon#init()} if necessary.
@@ -72,6 +68,7 @@ public class BlueLib implements ModInitializer {
      */
     public static void registerModEventListeners() {
         ServerLifecycleEvents.SERVER_STARTING.register(ReloadHandler::onServerStart);
+        ServerLifecycleEvents.END_DATA_PACK_RELOAD.register(ReloadHandler::onReload);
         ServerMessageEvents.ALLOW_CHAT_MESSAGE.register(ChatHandler::onAllowChat);
     }
 }

--- a/fabric/src/main/java/software/bluelib/example/event/ReloadHandler.java
+++ b/fabric/src/main/java/software/bluelib/example/event/ReloadHandler.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.packs.resources.CloseableResourceManager;
 import software.bluelib.BlueLibConstants;
 import software.bluelib.event.ReloadEventHandler;
 import software.bluelib.utils.logging.BaseLogLevel;
@@ -21,25 +22,15 @@ import software.bluelib.utils.logging.BaseLogger;
  * Key Methods:
  * <ul>
  * <li>{@link #onServerStart(MinecraftServer)} - Handles server starting events to initialize entity variants.</li>
- * <li>{@link #onReload()} - Handles reload events to refresh entity variants.</li>
+ * <li>{@link #onReload(MinecraftServer, CloseableResourceManager, boolean)} - Handles reload events to refresh entity variants.</li>
  * <li>{@link #LoadEntityVariants(MinecraftServer)} - Loads entity variants from JSON files into the server.</li>
  * </ul>
  *
  * @author MeAlam
- * @version 1.4.0
+ * @version 1.7.0
  * @since 1.0.0
  */
 public class ReloadHandler extends ReloadEventHandler {
-
-    /**
-     * The {@link MinecraftServer} instance for the server handling the events.
-     * <p>
-     * This is initialized when the server starts and used to load entity variants.
-     * </p>
-     *
-     * @since 1.0.0
-     */
-    private static MinecraftServer server;
 
     /**
      * Handles the server starting event to initialize the {@link MinecraftServer} instance
@@ -51,8 +42,7 @@ public class ReloadHandler extends ReloadEventHandler {
      */
     public static void onServerStart(MinecraftServer pServer) {
         BlueLibConstants.SCHEDULER = new ScheduledThreadPoolExecutor(1);
-        server = pServer;
-        ReloadHandler.LoadEntityVariants(server);
+        ReloadHandler.LoadEntityVariants(pServer);
         BaseLogger.log(BaseLogLevel.INFO, "Entity variants loaded.", true);
     }
 
@@ -65,14 +55,12 @@ public class ReloadHandler extends ReloadEventHandler {
      * @author MeAlam
      * @since 1.0.0
      */
-    public static void onReload() {
-        if (server != null) {
-            BlueLibConstants.SCHEDULER.schedule(() -> {
-                server.execute(() -> {
-                    ReloadHandler.LoadEntityVariants(server);
-                    BaseLogger.log(BaseLogLevel.INFO, "Entity variants reloaded.", true);
-                });
-            }, 1, TimeUnit.SECONDS);
+    public static void onReload(MinecraftServer pServer, CloseableResourceManager pCloseableResourceManager, boolean pBoolean) {
+        if (pServer != null) {
+            BlueLibConstants.SCHEDULER.schedule(() -> pServer.execute(() -> {
+                ReloadHandler.LoadEntityVariants(pServer);
+                BaseLogger.log(BaseLogLevel.INFO, "Entity variants reloaded.", true);
+            }), 1, TimeUnit.SECONDS);
         }
     }
 


### PR DESCRIPTION
## Description
Fixed /reload not reloading the Variants

## Changes
- **Change 1**: Added an Reload Event on Fabric

## How has this been tested?
* Joining world
* Add Datapack with Variants
* Type /reload
* See the variants in game

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Cleanup
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [x] My code follows the style guidelines of this project. [Contributing](https://github.com/MeAlam1/BlueLib/blob/1.21/CONTRIBUTING.md)
- [x] I have performed a self-review of my own code.
- [x] I have commented my code following the guidelines. [Contributing](https://github.com/MeAlam1/BlueLib/blob/1.21/CONTRIBUTING.md)
- [x] My changes generate no new warnings.

## Related Issues
<!-- List any issues that this PR is related to or closes. -->
