### PR TITLE
Created Data Pipeline

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,4 @@
-# 2.3.6
+# 2.3.7
 
 ## Warning:
 
@@ -9,14 +9,18 @@
 
 ## Added
 
-* Added all the MoLang for:
-    * VehicleEntity
-    * FlyingAnimal
-
-## Changed
-
-* Updated the ModAPI Enum to support more niche modding APIs.
-* Major Gradle cleanup, removing deprecated features and improving build speed.
+* Added Preset Caches with Json Deserializers, Codecs, DataComponentType and CompoundTags for easy saving/loading of
+  presets.
+    * IntRange
+    * FloatRange
+    * DoubleRange
+    * LongRange
+    * ShortRange
+    * ByteRange
+    * BlockPos
+    * Vector2 (as Float)
+    * Vector3 (as Float)
+* Added `DataComponentType` for easy registration of custom data components.
 
 ## Epilogue
 

--- a/changelog.md
+++ b/changelog.md
@@ -17,9 +17,11 @@
     * LongRange
     * ShortRange
     * ByteRange
-    * BlockPos
-    * Vector2 (as Float)
-    * Vector3 (as Float)
+    * BlockPos (With conversion from BlockPosCache to BlockPos)
+    * Vector2 (as Float) (With conversion from Vector2Cache to Vector2f)
+    * Vector3 (as Float) (With conversion from Vector3Cache to Vector3f)
+    * RGBAColor (With conversion from RGBAColorCache to Color)
+    * RGBColor (With conversion from RGBColorCache to Color)
 * Added `DataComponentType` for easy registration of custom data components.
 
 ## Epilogue

--- a/common/src/main/java/software/bluelib/BlueLibCommon.java
+++ b/common/src/main/java/software/bluelib/BlueLibCommon.java
@@ -15,15 +15,12 @@ import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.spongepowered.asm.launch.MixinBootstrap;
 import software.bluelib.api.event.mod.ModIntegration;
-import software.bluelib.api.molang.registry.MoLangContextRegistry;
 import software.bluelib.api.net.NetworkRegistry;
 import software.bluelib.api.utils.logging.BaseLogLevel;
 import software.bluelib.api.utils.logging.BaseLogger;
 import software.bluelib.internal.BlueTranslation;
-import software.bluelib.internal.registry.BlueEntityRegistry;
-import software.bluelib.internal.registry.BlueNetworkRegistry;
-import software.bluelib.internal.registry.BlueRecipeSerializerRegistry;
-import software.bluelib.internal.registry.BlueRecipeTypeRegistry;
+import software.bluelib.internal.registry.*;
+import software.bluelib.internal.registry.molang.BlueMoLangContextRegistry;
 
 @ApiStatus.Internal
 public class BlueLibCommon {
@@ -52,7 +49,8 @@ public class BlueLibCommon {
 		BlueEntityRegistry.init();
 		BlueRecipeTypeRegistry.init();
 		BlueRecipeSerializerRegistry.init();
-		MoLangContextRegistry.init();
+		BlueMoLangContextRegistry.init();
+		BlueDataComponentRegistry.init();
 	}
 
 	public static void doClientRegistration() {

--- a/common/src/main/java/software/bluelib/BlueLibConstants.java
+++ b/common/src/main/java/software/bluelib/BlueLibConstants.java
@@ -7,16 +7,12 @@
  */
 package software.bluelib;
 
-import com.mojang.serialization.Codec;
 import java.util.List;
 import java.util.ServiceLoader;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.function.Supplier;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
-import net.minecraft.core.component.DataComponentType;
-import net.minecraft.network.codec.ByteBufCodecs;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.MinecraftServer;
 import org.jetbrains.annotations.NotNull;
@@ -51,9 +47,6 @@ public class BlueLibConstants implements BuildDetails {
 
 	@NotNull
 	public static final String MOD_ID = "bluelib";
-
-	@NotNull
-	public static final Supplier<DataComponentType<Long>> STACK_ANIMATABLE_ID_COMPONENT = PlatformHelper.REGISTRY.registerDataComponent("stack_animatable_id", builder -> builder.persistent(Codec.LONG).networkSynchronized(ByteBufCodecs.VAR_LONG));
 
 	@NotNull
 	public static final String MOD_NAME = "BlueLib";

--- a/common/src/main/java/software/bluelib/api/json/cache/IntRangeCache.java
+++ b/common/src/main/java/software/bluelib/api/json/cache/IntRangeCache.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2024 BlueLib Contributors
+ *
+ * This Source Code Form is subject to the terms of the MIT License.
+ * If a copy of the MIT License was not distributed with this file,
+ * You can obtain one at https://opensource.org/licenses/MIT.
+ */
+package software.bluelib.api.json.cache;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.DataResult;
+import com.mojang.serialization.Dynamic;
+import net.minecraft.core.component.DataComponentType;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.NbtOps;
+import org.jetbrains.annotations.NotNull;
+import software.bluelib.api.json.deserializer.IntRange;
+
+public record IntRangeCache(
+		@NotNull Integer min,
+		@NotNull Integer max) {
+
+	public static final Codec<IntRangeCache> CODEC = Codec.PASSTHROUGH.comapFlatMap(
+			dynamic -> {
+				CompoundTag tag = (CompoundTag) dynamic.convert(NbtOps.INSTANCE).getValue();
+				return DataResult.success(IntRangeCache.readFromNBT(tag));
+			},
+			boneCache -> {
+				CompoundTag tag = new CompoundTag();
+				boneCache.writeToNBT(tag);
+				return new Dynamic<>(NbtOps.INSTANCE, tag);
+			});
+
+	public static final DataComponentType<IntRangeCache> INT_RANGE_DATA = DataComponentType.<IntRangeCache>builder()
+			.persistent(CODEC)
+			.build();
+
+	public void writeToNBT(@NotNull CompoundTag pTag) {
+		pTag.putInt("Min", min);
+		pTag.putInt("Max", max);
+	}
+
+	@NotNull
+	public static IntRangeCache readFromNBT(@NotNull CompoundTag pTag) {
+		return new IntRangeCache(pTag.getInt("Min"), pTag.getInt("Max"));
+	}
+
+	@NotNull
+	public static IntRangeCache construct(@NotNull IntRange pIntRange) {
+		return new IntRangeCache(pIntRange.min(), pIntRange.max());
+	}
+}

--- a/common/src/main/java/software/bluelib/api/json/cache/color/RGBAColorCache.java
+++ b/common/src/main/java/software/bluelib/api/json/cache/color/RGBAColorCache.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2024 BlueLib Contributors
+ *
+ * This Source Code Form is subject to the terms of the MIT License.
+ * If a copy of the MIT License was not distributed with this file,
+ * You can obtain one at https://opensource.org/licenses/MIT.
+ */
+package software.bluelib.api.json.cache.color;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.DataResult;
+import com.mojang.serialization.Dynamic;
+import java.awt.*;
+import net.minecraft.core.component.DataComponentType;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.NbtOps;
+import org.jetbrains.annotations.NotNull;
+import software.bluelib.api.json.deserializer.color.RGBAColor;
+
+public record RGBAColorCache(
+		@NotNull Integer red,
+		@NotNull Integer green,
+		@NotNull Integer blue,
+		@NotNull Integer alpha) {
+
+	public static final Codec<RGBAColorCache> CODEC = Codec.PASSTHROUGH.comapFlatMap(
+			dynamic -> {
+				CompoundTag tag = (CompoundTag) dynamic.convert(NbtOps.INSTANCE).getValue();
+				return DataResult.success(RGBAColorCache.readFromNBT(tag));
+			},
+			colorCache -> {
+				CompoundTag tag = new CompoundTag();
+				colorCache.writeToNBT(tag);
+				return new Dynamic<>(NbtOps.INSTANCE, tag);
+			});
+
+	public static final DataComponentType<RGBAColorCache> RGBA_COLOR_DATA = DataComponentType.<RGBAColorCache>builder()
+			.persistent(CODEC)
+			.build();
+
+	public void writeToNBT(@NotNull CompoundTag pTag) {
+		pTag.putInt("Red", red);
+		pTag.putInt("Green", green);
+		pTag.putInt("Blue", blue);
+		pTag.putInt("Alpha", alpha);
+	}
+
+	@NotNull
+	public static RGBAColorCache readFromNBT(@NotNull CompoundTag pTag) {
+		return new RGBAColorCache(pTag.getInt("Red"), pTag.getInt("Green"), pTag.getInt("Blue"), pTag.getInt("Alpha"));
+	}
+
+	@NotNull
+	public static RGBAColorCache construct(@NotNull RGBAColor pColor) {
+		return new RGBAColorCache(pColor.red(), pColor.green(), pColor.blue(), pColor.alpha());
+	}
+
+	public static Color convert(@NotNull RGBAColor pColor) {
+		return new Color(pColor.red(), pColor.green(), pColor.blue(), pColor.alpha());
+	}
+
+	public static Color convert(@NotNull RGBAColorCache pColor) {
+		return new Color(pColor.red(), pColor.green(), pColor.blue(), pColor.alpha());
+	}
+}

--- a/common/src/main/java/software/bluelib/api/json/cache/color/RGBColorCache.java
+++ b/common/src/main/java/software/bluelib/api/json/cache/color/RGBColorCache.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2024 BlueLib Contributors
+ *
+ * This Source Code Form is subject to the terms of the MIT License.
+ * If a copy of the MIT License was not distributed with this file,
+ * You can obtain one at https://opensource.org/licenses/MIT.
+ */
+package software.bluelib.api.json.cache.color;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.DataResult;
+import com.mojang.serialization.Dynamic;
+import java.awt.*;
+import net.minecraft.core.component.DataComponentType;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.NbtOps;
+import org.jetbrains.annotations.NotNull;
+import software.bluelib.api.json.deserializer.color.RGBColor;
+
+public record RGBColorCache(
+		@NotNull Integer red,
+		@NotNull Integer green,
+		@NotNull Integer blue) {
+
+	public static final Codec<RGBColorCache> CODEC = Codec.PASSTHROUGH.comapFlatMap(
+			dynamic -> {
+				CompoundTag tag = (CompoundTag) dynamic.convert(NbtOps.INSTANCE).getValue();
+				return DataResult.success(RGBColorCache.readFromNBT(tag));
+			},
+			colorCache -> {
+				CompoundTag tag = new CompoundTag();
+				colorCache.writeToNBT(tag);
+				return new Dynamic<>(NbtOps.INSTANCE, tag);
+			});
+
+	public static final DataComponentType<RGBColorCache> RGB_COLOR_DATA = DataComponentType.<RGBColorCache>builder()
+			.persistent(CODEC)
+			.build();
+
+	public void writeToNBT(@NotNull CompoundTag pTag) {
+		pTag.putInt("Red", red);
+		pTag.putInt("Green", green);
+		pTag.putInt("Blue", blue);
+	}
+
+	@NotNull
+	public static RGBColorCache readFromNBT(@NotNull CompoundTag pTag) {
+		return new RGBColorCache(pTag.getInt("Red"), pTag.getInt("Green"), pTag.getInt("Blue"));
+	}
+
+	@NotNull
+	public static RGBColorCache construct(@NotNull RGBColor pColor) {
+		return new RGBColorCache(pColor.red(), pColor.green(), pColor.blue());
+	}
+
+	public static Color convert(@NotNull RGBColor pColor) {
+		return new Color(pColor.red(), pColor.green(), pColor.blue());
+	}
+
+	public static Color convert(@NotNull RGBColorCache pColor) {
+		return new Color(pColor.red(), pColor.green(), pColor.blue());
+	}
+}

--- a/common/src/main/java/software/bluelib/api/json/cache/pos/BlockPosCache.java
+++ b/common/src/main/java/software/bluelib/api/json/cache/pos/BlockPosCache.java
@@ -51,4 +51,12 @@ public record BlockPosCache(
 	public static BlockPosCache construct(@NotNull BlockPos pBlockPos) {
 		return new BlockPosCache(pBlockPos.x(), pBlockPos.y(), pBlockPos.z());
 	}
+
+	public static net.minecraft.core.BlockPos convert(@NotNull BlockPos pPos) {
+		return new net.minecraft.core.BlockPos(pPos.x(), pPos.y(), pPos.z());
+	}
+
+	public static net.minecraft.core.BlockPos convert(@NotNull BlockPosCache pPos) {
+		return new net.minecraft.core.BlockPos(pPos.x(), pPos.y(), pPos.z());
+	}
 }

--- a/common/src/main/java/software/bluelib/api/json/cache/pos/BlockPosCache.java
+++ b/common/src/main/java/software/bluelib/api/json/cache/pos/BlockPosCache.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2024 BlueLib Contributors
+ *
+ * This Source Code Form is subject to the terms of the MIT License.
+ * If a copy of the MIT License was not distributed with this file,
+ * You can obtain one at https://opensource.org/licenses/MIT.
+ */
+package software.bluelib.api.json.cache.pos;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.DataResult;
+import com.mojang.serialization.Dynamic;
+import net.minecraft.core.component.DataComponentType;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.NbtOps;
+import org.jetbrains.annotations.NotNull;
+import software.bluelib.api.json.deserializer.pos.BlockPos;
+
+public record BlockPosCache(
+		@NotNull Integer x,
+		@NotNull Integer y,
+		@NotNull Integer z) {
+
+	public static final Codec<BlockPosCache> CODEC = Codec.PASSTHROUGH.comapFlatMap(
+			dynamic -> {
+				CompoundTag tag = (CompoundTag) dynamic.convert(NbtOps.INSTANCE).getValue();
+				return DataResult.success(BlockPosCache.readFromNBT(tag));
+			},
+			blockPosCache -> {
+				CompoundTag tag = new CompoundTag();
+				blockPosCache.writeToNBT(tag);
+				return new Dynamic<>(NbtOps.INSTANCE, tag);
+			});
+
+	public static final DataComponentType<BlockPosCache> BLOCK_POS_DATA = DataComponentType.<BlockPosCache>builder()
+			.persistent(CODEC)
+			.build();
+
+	public void writeToNBT(@NotNull CompoundTag pTag) {
+		pTag.putInt("x", x);
+		pTag.putInt("y", y);
+		pTag.putInt("z", z);
+	}
+
+	@NotNull
+	public static BlockPosCache readFromNBT(@NotNull CompoundTag pTag) {
+		return new BlockPosCache(pTag.getInt("x"), pTag.getInt("y"), pTag.getInt("z"));
+	}
+
+	@NotNull
+	public static BlockPosCache construct(@NotNull BlockPos pBlockPos) {
+		return new BlockPosCache(pBlockPos.x(), pBlockPos.y(), pBlockPos.z());
+	}
+}

--- a/common/src/main/java/software/bluelib/api/json/cache/pos/Vector2Cache.java
+++ b/common/src/main/java/software/bluelib/api/json/cache/pos/Vector2Cache.java
@@ -14,6 +14,7 @@ import net.minecraft.core.component.DataComponentType;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.NbtOps;
 import org.jetbrains.annotations.NotNull;
+import org.joml.Vector2f;
 import software.bluelib.api.json.deserializer.pos.Vector2;
 
 public record Vector2Cache(
@@ -48,5 +49,13 @@ public record Vector2Cache(
 	@NotNull
 	public static Vector2Cache construct(@NotNull Vector2 pVectorRange) {
 		return new Vector2Cache(pVectorRange.x(), pVectorRange.y());
+	}
+
+	public static Vector2f convert(@NotNull Vector2 pVector) {
+		return new Vector2f(pVector.x(), pVector.y());
+	}
+
+	public static Vector2f convert(@NotNull Vector2Cache pVector) {
+		return new Vector2f(pVector.x(), pVector.y());
 	}
 }

--- a/common/src/main/java/software/bluelib/api/json/cache/pos/Vector2Cache.java
+++ b/common/src/main/java/software/bluelib/api/json/cache/pos/Vector2Cache.java
@@ -5,7 +5,7 @@
  * If a copy of the MIT License was not distributed with this file,
  * You can obtain one at https://opensource.org/licenses/MIT.
  */
-package software.bluelib.api.json.cache.range;
+package software.bluelib.api.json.cache.pos;
 
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.DataResult;
@@ -14,39 +14,39 @@ import net.minecraft.core.component.DataComponentType;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.NbtOps;
 import org.jetbrains.annotations.NotNull;
-import software.bluelib.api.json.deserializer.range.ShortRange;
+import software.bluelib.api.json.deserializer.pos.Vector2;
 
-public record ShortRangeCache(
-		@NotNull Short min,
-		@NotNull Short max) {
+public record Vector2Cache(
+		@NotNull Float x,
+		@NotNull Float y) {
 
-	public static final Codec<ShortRangeCache> CODEC = Codec.PASSTHROUGH.comapFlatMap(
+	public static final Codec<Vector2Cache> CODEC = Codec.PASSTHROUGH.comapFlatMap(
 			dynamic -> {
 				CompoundTag tag = (CompoundTag) dynamic.convert(NbtOps.INSTANCE).getValue();
-				return DataResult.success(ShortRangeCache.readFromNBT(tag));
+				return DataResult.success(Vector2Cache.readFromNBT(tag));
 			},
-			shortRangeCache -> {
+			vector2Cache -> {
 				CompoundTag tag = new CompoundTag();
-				shortRangeCache.writeToNBT(tag);
+				vector2Cache.writeToNBT(tag);
 				return new Dynamic<>(NbtOps.INSTANCE, tag);
 			});
 
-	public static final DataComponentType<ShortRangeCache> SHORT_RANGE_DATA = DataComponentType.<ShortRangeCache>builder()
+	public static final DataComponentType<Vector2Cache> VECTOR2_DATA = DataComponentType.<Vector2Cache>builder()
 			.persistent(CODEC)
 			.build();
 
 	public void writeToNBT(@NotNull CompoundTag pTag) {
-		pTag.putShort("Min", min);
-		pTag.putShort("Max", max);
+		pTag.putFloat("x", x);
+		pTag.putFloat("y", y);
 	}
 
 	@NotNull
-	public static ShortRangeCache readFromNBT(@NotNull CompoundTag pTag) {
-		return new ShortRangeCache(pTag.getShort("Min"), pTag.getShort("Max"));
+	public static Vector2Cache readFromNBT(@NotNull CompoundTag pTag) {
+		return new Vector2Cache(pTag.getFloat("x"), pTag.getFloat("y"));
 	}
 
 	@NotNull
-	public static ShortRangeCache construct(@NotNull ShortRange pShortRange) {
-		return new ShortRangeCache(pShortRange.min(), pShortRange.max());
+	public static Vector2Cache construct(@NotNull Vector2 pVectorRange) {
+		return new Vector2Cache(pVectorRange.x(), pVectorRange.y());
 	}
 }

--- a/common/src/main/java/software/bluelib/api/json/cache/pos/Vector3Cache.java
+++ b/common/src/main/java/software/bluelib/api/json/cache/pos/Vector3Cache.java
@@ -14,6 +14,7 @@ import net.minecraft.core.component.DataComponentType;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.NbtOps;
 import org.jetbrains.annotations.NotNull;
+import org.joml.Vector3f;
 import software.bluelib.api.json.deserializer.pos.Vector3;
 
 public record Vector3Cache(
@@ -50,5 +51,13 @@ public record Vector3Cache(
 	@NotNull
 	public static Vector3Cache construct(@NotNull Vector3 pVectorRange) {
 		return new Vector3Cache(pVectorRange.x(), pVectorRange.y(), pVectorRange.z());
+	}
+
+	public static Vector3f convert(@NotNull Vector3 pVector) {
+		return new Vector3f(pVector.x(), pVector.y(), pVector.z());
+	}
+
+	public static Vector3f convert(@NotNull Vector3Cache pVector) {
+		return new Vector3f(pVector.x(), pVector.y(), pVector.z());
 	}
 }

--- a/common/src/main/java/software/bluelib/api/json/cache/pos/Vector3Cache.java
+++ b/common/src/main/java/software/bluelib/api/json/cache/pos/Vector3Cache.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2024 BlueLib Contributors
+ *
+ * This Source Code Form is subject to the terms of the MIT License.
+ * If a copy of the MIT License was not distributed with this file,
+ * You can obtain one at https://opensource.org/licenses/MIT.
+ */
+package software.bluelib.api.json.cache.pos;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.DataResult;
+import com.mojang.serialization.Dynamic;
+import net.minecraft.core.component.DataComponentType;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.NbtOps;
+import org.jetbrains.annotations.NotNull;
+import software.bluelib.api.json.deserializer.pos.Vector3;
+
+public record Vector3Cache(
+		@NotNull Float x,
+		@NotNull Float y,
+		@NotNull Float z) {
+
+	public static final Codec<Vector3Cache> CODEC = Codec.PASSTHROUGH.comapFlatMap(
+			dynamic -> {
+				CompoundTag tag = (CompoundTag) dynamic.convert(NbtOps.INSTANCE).getValue();
+				return DataResult.success(Vector3Cache.readFromNBT(tag));
+			},
+			vector3Cache -> {
+				CompoundTag tag = new CompoundTag();
+				vector3Cache.writeToNBT(tag);
+				return new Dynamic<>(NbtOps.INSTANCE, tag);
+			});
+
+	public static final DataComponentType<Vector3Cache> VECTOR3_DATA = DataComponentType.<Vector3Cache>builder()
+			.persistent(CODEC)
+			.build();
+
+	public void writeToNBT(@NotNull CompoundTag pTag) {
+		pTag.putFloat("x", x);
+		pTag.putFloat("y", y);
+		pTag.putFloat("z", z);
+	}
+
+	@NotNull
+	public static Vector3Cache readFromNBT(@NotNull CompoundTag pTag) {
+		return new Vector3Cache(pTag.getFloat("x"), pTag.getFloat("y"), pTag.getFloat("z"));
+	}
+
+	@NotNull
+	public static Vector3Cache construct(@NotNull Vector3 pVectorRange) {
+		return new Vector3Cache(pVectorRange.x(), pVectorRange.y(), pVectorRange.z());
+	}
+}

--- a/common/src/main/java/software/bluelib/api/json/cache/range/ByteRangeCache.java
+++ b/common/src/main/java/software/bluelib/api/json/cache/range/ByteRangeCache.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2024 BlueLib Contributors
+ *
+ * This Source Code Form is subject to the terms of the MIT License.
+ * If a copy of the MIT License was not distributed with this file,
+ * You can obtain one at https://opensource.org/licenses/MIT.
+ */
+package software.bluelib.api.json.cache.range;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.DataResult;
+import com.mojang.serialization.Dynamic;
+import net.minecraft.core.component.DataComponentType;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.NbtOps;
+import org.jetbrains.annotations.NotNull;
+import software.bluelib.api.json.deserializer.range.ByteRange;
+
+public record ByteRangeCache(
+		@NotNull Byte min,
+		@NotNull Byte max) {
+
+	public static final Codec<ByteRangeCache> CODEC = Codec.PASSTHROUGH.comapFlatMap(
+			dynamic -> {
+				CompoundTag tag = (CompoundTag) dynamic.convert(NbtOps.INSTANCE).getValue();
+				return DataResult.success(ByteRangeCache.readFromNBT(tag));
+			},
+			boneCache -> {
+				CompoundTag tag = new CompoundTag();
+				boneCache.writeToNBT(tag);
+				return new Dynamic<>(NbtOps.INSTANCE, tag);
+			});
+
+	public static final DataComponentType<ByteRangeCache> BYTE_RANGE_DATA = DataComponentType.<ByteRangeCache>builder()
+			.persistent(CODEC)
+			.build();
+
+	public void writeToNBT(@NotNull CompoundTag pTag) {
+		pTag.putByte("Min", min);
+		pTag.putByte("Max", max);
+	}
+
+	@NotNull
+	public static ByteRangeCache readFromNBT(@NotNull CompoundTag pTag) {
+		return new ByteRangeCache(pTag.getByte("Min"), pTag.getByte("Max"));
+	}
+
+	@NotNull
+	public static ByteRangeCache construct(@NotNull ByteRange pByteRange) {
+		return new ByteRangeCache(pByteRange.min(), pByteRange.max());
+	}
+}

--- a/common/src/main/java/software/bluelib/api/json/cache/range/ByteRangeCache.java
+++ b/common/src/main/java/software/bluelib/api/json/cache/range/ByteRangeCache.java
@@ -25,9 +25,9 @@ public record ByteRangeCache(
 				CompoundTag tag = (CompoundTag) dynamic.convert(NbtOps.INSTANCE).getValue();
 				return DataResult.success(ByteRangeCache.readFromNBT(tag));
 			},
-			boneCache -> {
+			byteRangeCache -> {
 				CompoundTag tag = new CompoundTag();
-				boneCache.writeToNBT(tag);
+				byteRangeCache.writeToNBT(tag);
 				return new Dynamic<>(NbtOps.INSTANCE, tag);
 			});
 

--- a/common/src/main/java/software/bluelib/api/json/cache/range/DoubleRangeCache.java
+++ b/common/src/main/java/software/bluelib/api/json/cache/range/DoubleRangeCache.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2024 BlueLib Contributors
+ *
+ * This Source Code Form is subject to the terms of the MIT License.
+ * If a copy of the MIT License was not distributed with this file,
+ * You can obtain one at https://opensource.org/licenses/MIT.
+ */
+package software.bluelib.api.json.cache.range;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.DataResult;
+import com.mojang.serialization.Dynamic;
+import net.minecraft.core.component.DataComponentType;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.NbtOps;
+import org.jetbrains.annotations.NotNull;
+import software.bluelib.api.json.deserializer.range.DoubleRange;
+
+public record DoubleRangeCache(
+		@NotNull Double min,
+		@NotNull Double max) {
+
+	public static final Codec<DoubleRangeCache> CODEC = Codec.PASSTHROUGH.comapFlatMap(
+			dynamic -> {
+				CompoundTag tag = (CompoundTag) dynamic.convert(NbtOps.INSTANCE).getValue();
+				return DataResult.success(DoubleRangeCache.readFromNBT(tag));
+			},
+			boneCache -> {
+				CompoundTag tag = new CompoundTag();
+				boneCache.writeToNBT(tag);
+				return new Dynamic<>(NbtOps.INSTANCE, tag);
+			});
+
+	public static final DataComponentType<DoubleRangeCache> DOUBLE_RANGE_DATA = DataComponentType.<DoubleRangeCache>builder()
+			.persistent(CODEC)
+			.build();
+
+	public void writeToNBT(@NotNull CompoundTag pTag) {
+		pTag.putDouble("Min", min);
+		pTag.putDouble("Max", max);
+	}
+
+	@NotNull
+	public static DoubleRangeCache readFromNBT(@NotNull CompoundTag pTag) {
+		return new DoubleRangeCache(pTag.getDouble("Min"), pTag.getDouble("Max"));
+	}
+
+	@NotNull
+	public static DoubleRangeCache construct(@NotNull DoubleRange pDoubleRange) {
+		return new DoubleRangeCache(pDoubleRange.min(), pDoubleRange.max());
+	}
+}

--- a/common/src/main/java/software/bluelib/api/json/cache/range/DoubleRangeCache.java
+++ b/common/src/main/java/software/bluelib/api/json/cache/range/DoubleRangeCache.java
@@ -25,9 +25,9 @@ public record DoubleRangeCache(
 				CompoundTag tag = (CompoundTag) dynamic.convert(NbtOps.INSTANCE).getValue();
 				return DataResult.success(DoubleRangeCache.readFromNBT(tag));
 			},
-			boneCache -> {
+			doubleRangeCache -> {
 				CompoundTag tag = new CompoundTag();
-				boneCache.writeToNBT(tag);
+				doubleRangeCache.writeToNBT(tag);
 				return new Dynamic<>(NbtOps.INSTANCE, tag);
 			});
 

--- a/common/src/main/java/software/bluelib/api/json/cache/range/FloatRangeCache.java
+++ b/common/src/main/java/software/bluelib/api/json/cache/range/FloatRangeCache.java
@@ -25,9 +25,9 @@ public record FloatRangeCache(
 				CompoundTag tag = (CompoundTag) dynamic.convert(NbtOps.INSTANCE).getValue();
 				return DataResult.success(FloatRangeCache.readFromNBT(tag));
 			},
-			boneCache -> {
+			floatRangeCache -> {
 				CompoundTag tag = new CompoundTag();
-				boneCache.writeToNBT(tag);
+				floatRangeCache.writeToNBT(tag);
 				return new Dynamic<>(NbtOps.INSTANCE, tag);
 			});
 

--- a/common/src/main/java/software/bluelib/api/json/cache/range/FloatRangeCache.java
+++ b/common/src/main/java/software/bluelib/api/json/cache/range/FloatRangeCache.java
@@ -5,7 +5,7 @@
  * If a copy of the MIT License was not distributed with this file,
  * You can obtain one at https://opensource.org/licenses/MIT.
  */
-package software.bluelib.api.json.cache;
+package software.bluelib.api.json.cache.range;
 
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.DataResult;
@@ -14,16 +14,16 @@ import net.minecraft.core.component.DataComponentType;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.NbtOps;
 import org.jetbrains.annotations.NotNull;
-import software.bluelib.api.json.deserializer.IntRange;
+import software.bluelib.api.json.deserializer.range.FloatRange;
 
-public record IntRangeCache(
-		@NotNull Integer min,
-		@NotNull Integer max) {
+public record FloatRangeCache(
+		@NotNull Float min,
+		@NotNull Float max) {
 
-	public static final Codec<IntRangeCache> CODEC = Codec.PASSTHROUGH.comapFlatMap(
+	public static final Codec<FloatRangeCache> CODEC = Codec.PASSTHROUGH.comapFlatMap(
 			dynamic -> {
 				CompoundTag tag = (CompoundTag) dynamic.convert(NbtOps.INSTANCE).getValue();
-				return DataResult.success(IntRangeCache.readFromNBT(tag));
+				return DataResult.success(FloatRangeCache.readFromNBT(tag));
 			},
 			boneCache -> {
 				CompoundTag tag = new CompoundTag();
@@ -31,22 +31,22 @@ public record IntRangeCache(
 				return new Dynamic<>(NbtOps.INSTANCE, tag);
 			});
 
-	public static final DataComponentType<IntRangeCache> INT_RANGE_DATA = DataComponentType.<IntRangeCache>builder()
+	public static final DataComponentType<FloatRangeCache> FLOAT_RANGE_DATA = DataComponentType.<FloatRangeCache>builder()
 			.persistent(CODEC)
 			.build();
 
 	public void writeToNBT(@NotNull CompoundTag pTag) {
-		pTag.putInt("Min", min);
-		pTag.putInt("Max", max);
+		pTag.putFloat("Min", min);
+		pTag.putFloat("Max", max);
 	}
 
 	@NotNull
-	public static IntRangeCache readFromNBT(@NotNull CompoundTag pTag) {
-		return new IntRangeCache(pTag.getInt("Min"), pTag.getInt("Max"));
+	public static FloatRangeCache readFromNBT(@NotNull CompoundTag pTag) {
+		return new FloatRangeCache(pTag.getFloat("Min"), pTag.getFloat("Max"));
 	}
 
 	@NotNull
-	public static IntRangeCache construct(@NotNull IntRange pIntRange) {
-		return new IntRangeCache(pIntRange.min(), pIntRange.max());
+	public static FloatRangeCache construct(@NotNull FloatRange pFloatRange) {
+		return new FloatRangeCache(pFloatRange.min(), pFloatRange.max());
 	}
 }

--- a/common/src/main/java/software/bluelib/api/json/cache/range/IntRangeCache.java
+++ b/common/src/main/java/software/bluelib/api/json/cache/range/IntRangeCache.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2024 BlueLib Contributors
+ *
+ * This Source Code Form is subject to the terms of the MIT License.
+ * If a copy of the MIT License was not distributed with this file,
+ * You can obtain one at https://opensource.org/licenses/MIT.
+ */
+package software.bluelib.api.json.cache.range;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.DataResult;
+import com.mojang.serialization.Dynamic;
+import net.minecraft.core.component.DataComponentType;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.NbtOps;
+import org.jetbrains.annotations.NotNull;
+import software.bluelib.api.json.deserializer.range.IntRange;
+
+public record IntRangeCache(
+		@NotNull Integer min,
+		@NotNull Integer max) {
+
+	public static final Codec<IntRangeCache> CODEC = Codec.PASSTHROUGH.comapFlatMap(
+			dynamic -> {
+				CompoundTag tag = (CompoundTag) dynamic.convert(NbtOps.INSTANCE).getValue();
+				return DataResult.success(IntRangeCache.readFromNBT(tag));
+			},
+			boneCache -> {
+				CompoundTag tag = new CompoundTag();
+				boneCache.writeToNBT(tag);
+				return new Dynamic<>(NbtOps.INSTANCE, tag);
+			});
+
+	public static final DataComponentType<IntRangeCache> INT_RANGE_DATA = DataComponentType.<IntRangeCache>builder()
+			.persistent(CODEC)
+			.build();
+
+	public void writeToNBT(@NotNull CompoundTag pTag) {
+		pTag.putInt("Min", min);
+		pTag.putInt("Max", max);
+	}
+
+	@NotNull
+	public static IntRangeCache readFromNBT(@NotNull CompoundTag pTag) {
+		return new IntRangeCache(pTag.getInt("Min"), pTag.getInt("Max"));
+	}
+
+	@NotNull
+	public static IntRangeCache construct(@NotNull IntRange pIntRange) {
+		return new IntRangeCache(pIntRange.min(), pIntRange.max());
+	}
+}

--- a/common/src/main/java/software/bluelib/api/json/cache/range/IntRangeCache.java
+++ b/common/src/main/java/software/bluelib/api/json/cache/range/IntRangeCache.java
@@ -25,9 +25,9 @@ public record IntRangeCache(
 				CompoundTag tag = (CompoundTag) dynamic.convert(NbtOps.INSTANCE).getValue();
 				return DataResult.success(IntRangeCache.readFromNBT(tag));
 			},
-			boneCache -> {
+			intRangeCache -> {
 				CompoundTag tag = new CompoundTag();
-				boneCache.writeToNBT(tag);
+				intRangeCache.writeToNBT(tag);
 				return new Dynamic<>(NbtOps.INSTANCE, tag);
 			});
 

--- a/common/src/main/java/software/bluelib/api/json/cache/range/LongRangeCache.java
+++ b/common/src/main/java/software/bluelib/api/json/cache/range/LongRangeCache.java
@@ -25,9 +25,9 @@ public record LongRangeCache(
 				CompoundTag tag = (CompoundTag) dynamic.convert(NbtOps.INSTANCE).getValue();
 				return DataResult.success(LongRangeCache.readFromNBT(tag));
 			},
-			boneCache -> {
+			longRangeCache -> {
 				CompoundTag tag = new CompoundTag();
-				boneCache.writeToNBT(tag);
+				longRangeCache.writeToNBT(tag);
 				return new Dynamic<>(NbtOps.INSTANCE, tag);
 			});
 

--- a/common/src/main/java/software/bluelib/api/json/cache/range/LongRangeCache.java
+++ b/common/src/main/java/software/bluelib/api/json/cache/range/LongRangeCache.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2024 BlueLib Contributors
+ *
+ * This Source Code Form is subject to the terms of the MIT License.
+ * If a copy of the MIT License was not distributed with this file,
+ * You can obtain one at https://opensource.org/licenses/MIT.
+ */
+package software.bluelib.api.json.cache.range;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.DataResult;
+import com.mojang.serialization.Dynamic;
+import net.minecraft.core.component.DataComponentType;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.NbtOps;
+import org.jetbrains.annotations.NotNull;
+import software.bluelib.api.json.deserializer.range.LongRange;
+
+public record LongRangeCache(
+		@NotNull Long min,
+		@NotNull Long max) {
+
+	public static final Codec<LongRangeCache> CODEC = Codec.PASSTHROUGH.comapFlatMap(
+			dynamic -> {
+				CompoundTag tag = (CompoundTag) dynamic.convert(NbtOps.INSTANCE).getValue();
+				return DataResult.success(LongRangeCache.readFromNBT(tag));
+			},
+			boneCache -> {
+				CompoundTag tag = new CompoundTag();
+				boneCache.writeToNBT(tag);
+				return new Dynamic<>(NbtOps.INSTANCE, tag);
+			});
+
+	public static final DataComponentType<LongRangeCache> LONG_RANGE_DATA = DataComponentType.<LongRangeCache>builder()
+			.persistent(CODEC)
+			.build();
+
+	public void writeToNBT(@NotNull CompoundTag pTag) {
+		pTag.putLong("Min", min);
+		pTag.putLong("Max", max);
+	}
+
+	@NotNull
+	public static LongRangeCache readFromNBT(@NotNull CompoundTag pTag) {
+		return new LongRangeCache(pTag.getLong("Min"), pTag.getLong("Max"));
+	}
+
+	@NotNull
+	public static LongRangeCache construct(@NotNull LongRange pLongRange) {
+		return new LongRangeCache(pLongRange.min(), pLongRange.max());
+	}
+}

--- a/common/src/main/java/software/bluelib/api/json/cache/range/ShortRangeCache.java
+++ b/common/src/main/java/software/bluelib/api/json/cache/range/ShortRangeCache.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2024 BlueLib Contributors
+ *
+ * This Source Code Form is subject to the terms of the MIT License.
+ * If a copy of the MIT License was not distributed with this file,
+ * You can obtain one at https://opensource.org/licenses/MIT.
+ */
+package software.bluelib.api.json.cache.range;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.DataResult;
+import com.mojang.serialization.Dynamic;
+import net.minecraft.core.component.DataComponentType;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.NbtOps;
+import org.jetbrains.annotations.NotNull;
+import software.bluelib.api.json.deserializer.range.ShortRange;
+
+public record ShortRangeCache(
+		@NotNull Short min,
+		@NotNull Short max) {
+
+	public static final Codec<ShortRangeCache> CODEC = Codec.PASSTHROUGH.comapFlatMap(
+			dynamic -> {
+				CompoundTag tag = (CompoundTag) dynamic.convert(NbtOps.INSTANCE).getValue();
+				return DataResult.success(ShortRangeCache.readFromNBT(tag));
+			},
+			boneCache -> {
+				CompoundTag tag = new CompoundTag();
+				boneCache.writeToNBT(tag);
+				return new Dynamic<>(NbtOps.INSTANCE, tag);
+			});
+
+	public static final DataComponentType<ShortRangeCache> SHORT_RANGE_DATA = DataComponentType.<ShortRangeCache>builder()
+			.persistent(CODEC)
+			.build();
+
+	public void writeToNBT(@NotNull CompoundTag pTag) {
+		pTag.putShort("Min", min);
+		pTag.putShort("Max", max);
+	}
+
+	@NotNull
+	public static ShortRangeCache readFromNBT(@NotNull CompoundTag pTag) {
+		return new ShortRangeCache(pTag.getShort("Min"), pTag.getShort("Max"));
+	}
+
+	@NotNull
+	public static ShortRangeCache construct(@NotNull ShortRange pShortRange) {
+		return new ShortRangeCache(pShortRange.min(), pShortRange.max());
+	}
+}

--- a/common/src/main/java/software/bluelib/api/json/deserializer/IntRange.java
+++ b/common/src/main/java/software/bluelib/api/json/deserializer/IntRange.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2024 BlueLib Contributors
+ *
+ * This Source Code Form is subject to the terms of the MIT License.
+ * If a copy of the MIT License was not distributed with this file,
+ * You can obtain one at https://opensource.org/licenses/MIT.
+ */
+package software.bluelib.api.json.deserializer;
+
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import net.minecraft.util.GsonHelper;
+import org.jetbrains.annotations.NotNull;
+
+public record IntRange(
+		@NotNull Integer min,
+		@NotNull Integer max) {
+
+	@NotNull
+	public static JsonDeserializer<IntRange> deserializer() throws JsonParseException {
+		return (json, type, context) -> {
+			JsonObject obj = json.getAsJsonObject();
+
+			Integer min = GsonHelper.getAsInt(obj, "min");
+			Integer max = GsonHelper.getAsInt(obj, "max");
+
+			return new IntRange(
+					min,
+					max);
+		};
+	}
+}

--- a/common/src/main/java/software/bluelib/api/json/deserializer/color/RGBAColor.java
+++ b/common/src/main/java/software/bluelib/api/json/deserializer/color/RGBAColor.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2024 BlueLib Contributors
+ *
+ * This Source Code Form is subject to the terms of the MIT License.
+ * If a copy of the MIT License was not distributed with this file,
+ * You can obtain one at https://opensource.org/licenses/MIT.
+ */
+package software.bluelib.api.json.deserializer.color;
+
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import net.minecraft.util.GsonHelper;
+import org.jetbrains.annotations.NotNull;
+
+public record RGBAColor(
+		@NotNull Integer red,
+		@NotNull Integer green,
+		@NotNull Integer blue,
+		@NotNull Integer alpha) {
+
+	@NotNull
+	public static JsonDeserializer<RGBAColor> deserializer() throws JsonParseException {
+		return (json, type, context) -> {
+			JsonObject obj = json.getAsJsonObject();
+
+			int red = GsonHelper.getAsInt(obj, "red", 0);
+			int green = GsonHelper.getAsInt(obj, "green", 0);
+			int blue = GsonHelper.getAsInt(obj, "blue", 0);
+			int alpha = GsonHelper.getAsInt(obj, "alpha", 255);
+
+			return new RGBAColor(
+					Math.max(0, Math.min(255, red)),
+					Math.max(0, Math.min(255, green)),
+					Math.max(0, Math.min(255, blue)),
+					Math.max(0, Math.min(255, alpha)));
+		};
+	}
+}

--- a/common/src/main/java/software/bluelib/api/json/deserializer/color/RGBColor.java
+++ b/common/src/main/java/software/bluelib/api/json/deserializer/color/RGBColor.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2024 BlueLib Contributors
+ *
+ * This Source Code Form is subject to the terms of the MIT License.
+ * If a copy of the MIT License was not distributed with this file,
+ * You can obtain one at https://opensource.org/licenses/MIT.
+ */
+package software.bluelib.api.json.deserializer.color;
+
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import net.minecraft.util.GsonHelper;
+import org.jetbrains.annotations.NotNull;
+
+public record RGBColor(
+		@NotNull Integer red,
+		@NotNull Integer green,
+		@NotNull Integer blue) {
+
+	@NotNull
+	public static JsonDeserializer<RGBColor> deserializer() throws JsonParseException {
+		return (json, type, context) -> {
+			JsonObject obj = json.getAsJsonObject();
+
+			int red = GsonHelper.getAsInt(obj, "red", 0);
+			int green = GsonHelper.getAsInt(obj, "green", 0);
+			int blue = GsonHelper.getAsInt(obj, "blue", 0);
+
+			return new RGBColor(
+					Math.max(0, Math.min(255, red)),
+					Math.max(0, Math.min(255, green)),
+					Math.max(0, Math.min(255, blue)));
+		};
+	}
+}

--- a/common/src/main/java/software/bluelib/api/json/deserializer/pos/BlockPos.java
+++ b/common/src/main/java/software/bluelib/api/json/deserializer/pos/BlockPos.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2024 BlueLib Contributors
+ *
+ * This Source Code Form is subject to the terms of the MIT License.
+ * If a copy of the MIT License was not distributed with this file,
+ * You can obtain one at https://opensource.org/licenses/MIT.
+ */
+package software.bluelib.api.json.deserializer.pos;
+
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import net.minecraft.util.GsonHelper;
+import org.jetbrains.annotations.NotNull;
+
+public record BlockPos(
+		@NotNull Integer x,
+		@NotNull Integer y,
+		@NotNull Integer z) {
+
+	@NotNull
+	public static JsonDeserializer<BlockPos> deserializer() throws JsonParseException {
+		return (json, type, context) -> {
+			JsonObject obj = json.getAsJsonObject();
+
+			Integer x = GsonHelper.getAsInt(obj, "x", 0);
+			Integer y = GsonHelper.getAsInt(obj, "y", 0);
+			Integer z = GsonHelper.getAsInt(obj, "z", 0);
+
+			return new BlockPos(
+					x,
+					y,
+					z);
+		};
+	}
+}

--- a/common/src/main/java/software/bluelib/api/json/deserializer/pos/Vector2.java
+++ b/common/src/main/java/software/bluelib/api/json/deserializer/pos/Vector2.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2024 BlueLib Contributors
+ *
+ * This Source Code Form is subject to the terms of the MIT License.
+ * If a copy of the MIT License was not distributed with this file,
+ * You can obtain one at https://opensource.org/licenses/MIT.
+ */
+package software.bluelib.api.json.deserializer.pos;
+
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import net.minecraft.util.GsonHelper;
+import org.jetbrains.annotations.NotNull;
+
+public record Vector2(
+		@NotNull Float x,
+		@NotNull Float y) {
+
+	@NotNull
+	public static JsonDeserializer<Vector2> deserializer() throws JsonParseException {
+		return (json, type, context) -> {
+			JsonObject obj = json.getAsJsonObject();
+
+			Float x = GsonHelper.getAsFloat(obj, "x", 0);
+			Float y = GsonHelper.getAsFloat(obj, "y", 0);
+
+			return new Vector2(
+					x,
+					y);
+		};
+	}
+}

--- a/common/src/main/java/software/bluelib/api/json/deserializer/pos/Vector3.java
+++ b/common/src/main/java/software/bluelib/api/json/deserializer/pos/Vector3.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2024 BlueLib Contributors
+ *
+ * This Source Code Form is subject to the terms of the MIT License.
+ * If a copy of the MIT License was not distributed with this file,
+ * You can obtain one at https://opensource.org/licenses/MIT.
+ */
+package software.bluelib.api.json.deserializer.pos;
+
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import net.minecraft.util.GsonHelper;
+import org.jetbrains.annotations.NotNull;
+
+public record Vector3(
+		@NotNull Float x,
+		@NotNull Float y,
+		@NotNull Float z) {
+
+	@NotNull
+	public static JsonDeserializer<Vector3> deserializer() throws JsonParseException {
+		return (json, type, context) -> {
+			JsonObject obj = json.getAsJsonObject();
+
+			Float x = GsonHelper.getAsFloat(obj, "x", 0);
+			Float y = GsonHelper.getAsFloat(obj, "y", 0);
+			Float z = GsonHelper.getAsFloat(obj, "z", 0);
+
+			return new Vector3(
+					x,
+					y,
+					z);
+		};
+	}
+}

--- a/common/src/main/java/software/bluelib/api/json/deserializer/range/ByteRange.java
+++ b/common/src/main/java/software/bluelib/api/json/deserializer/range/ByteRange.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2024 BlueLib Contributors
+ *
+ * This Source Code Form is subject to the terms of the MIT License.
+ * If a copy of the MIT License was not distributed with this file,
+ * You can obtain one at https://opensource.org/licenses/MIT.
+ */
+package software.bluelib.api.json.deserializer.range;
+
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import net.minecraft.util.GsonHelper;
+import org.jetbrains.annotations.NotNull;
+
+public record ByteRange(
+		@NotNull Byte min,
+		@NotNull Byte max) {
+
+	@NotNull
+	public static JsonDeserializer<ByteRange> deserializer() throws JsonParseException {
+		return (json, type, context) -> {
+			JsonObject obj = json.getAsJsonObject();
+
+			Byte min = GsonHelper.getAsByte(obj, "min", (byte) 0);
+			Byte max = GsonHelper.getAsByte(obj, "max", (byte) 100);
+
+			return new ByteRange(
+					min,
+					max);
+		};
+	}
+}

--- a/common/src/main/java/software/bluelib/api/json/deserializer/range/DoubleRange.java
+++ b/common/src/main/java/software/bluelib/api/json/deserializer/range/DoubleRange.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2024 BlueLib Contributors
+ *
+ * This Source Code Form is subject to the terms of the MIT License.
+ * If a copy of the MIT License was not distributed with this file,
+ * You can obtain one at https://opensource.org/licenses/MIT.
+ */
+package software.bluelib.api.json.deserializer.range;
+
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import net.minecraft.util.GsonHelper;
+import org.jetbrains.annotations.NotNull;
+
+public record DoubleRange(
+		@NotNull Double min,
+		@NotNull Double max) {
+
+	@NotNull
+	public static JsonDeserializer<DoubleRange> deserializer() throws JsonParseException {
+		return (json, type, context) -> {
+			JsonObject obj = json.getAsJsonObject();
+
+			Double min = GsonHelper.getAsDouble(obj, "min", 0);
+			Double max = GsonHelper.getAsDouble(obj, "max", 100);
+
+			return new DoubleRange(
+					min,
+					max);
+		};
+	}
+}

--- a/common/src/main/java/software/bluelib/api/json/deserializer/range/FloatRange.java
+++ b/common/src/main/java/software/bluelib/api/json/deserializer/range/FloatRange.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2024 BlueLib Contributors
+ *
+ * This Source Code Form is subject to the terms of the MIT License.
+ * If a copy of the MIT License was not distributed with this file,
+ * You can obtain one at https://opensource.org/licenses/MIT.
+ */
+package software.bluelib.api.json.deserializer.range;
+
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import net.minecraft.util.GsonHelper;
+import org.jetbrains.annotations.NotNull;
+
+public record FloatRange(
+		@NotNull Float min,
+		@NotNull Float max) {
+
+	@NotNull
+	public static JsonDeserializer<FloatRange> deserializer() throws JsonParseException {
+		return (json, type, context) -> {
+			JsonObject obj = json.getAsJsonObject();
+
+			Float min = GsonHelper.getAsFloat(obj, "min", 0);
+			Float max = GsonHelper.getAsFloat(obj, "max", 100);
+
+			return new FloatRange(
+					min,
+					max);
+		};
+	}
+}

--- a/common/src/main/java/software/bluelib/api/json/deserializer/range/IntRange.java
+++ b/common/src/main/java/software/bluelib/api/json/deserializer/range/IntRange.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2024 BlueLib Contributors
+ *
+ * This Source Code Form is subject to the terms of the MIT License.
+ * If a copy of the MIT License was not distributed with this file,
+ * You can obtain one at https://opensource.org/licenses/MIT.
+ */
+package software.bluelib.api.json.deserializer.range;
+
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import net.minecraft.util.GsonHelper;
+import org.jetbrains.annotations.NotNull;
+
+public record IntRange(
+		@NotNull Integer min,
+		@NotNull Integer max) {
+
+	@NotNull
+	public static JsonDeserializer<IntRange> deserializer() throws JsonParseException {
+		return (json, type, context) -> {
+			JsonObject obj = json.getAsJsonObject();
+
+			Integer min = GsonHelper.getAsInt(obj, "min", 0);
+			Integer max = GsonHelper.getAsInt(obj, "max", 100);
+
+			return new IntRange(
+					min,
+					max);
+		};
+	}
+}

--- a/common/src/main/java/software/bluelib/api/json/deserializer/range/LongRange.java
+++ b/common/src/main/java/software/bluelib/api/json/deserializer/range/LongRange.java
@@ -5,7 +5,7 @@
  * If a copy of the MIT License was not distributed with this file,
  * You can obtain one at https://opensource.org/licenses/MIT.
  */
-package software.bluelib.api.json.deserializer;
+package software.bluelib.api.json.deserializer.range;
 
 import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonObject;
@@ -13,19 +13,19 @@ import com.google.gson.JsonParseException;
 import net.minecraft.util.GsonHelper;
 import org.jetbrains.annotations.NotNull;
 
-public record IntRange(
-		@NotNull Integer min,
-		@NotNull Integer max) {
+public record LongRange(
+		@NotNull Long min,
+		@NotNull Long max) {
 
 	@NotNull
-	public static JsonDeserializer<IntRange> deserializer() throws JsonParseException {
+	public static JsonDeserializer<LongRange> deserializer() throws JsonParseException {
 		return (json, type, context) -> {
 			JsonObject obj = json.getAsJsonObject();
 
-			Integer min = GsonHelper.getAsInt(obj, "min");
-			Integer max = GsonHelper.getAsInt(obj, "max");
+			Long min = GsonHelper.getAsLong(obj, "min", 0);
+			Long max = GsonHelper.getAsLong(obj, "max", 100);
 
-			return new IntRange(
+			return new LongRange(
 					min,
 					max);
 		};

--- a/common/src/main/java/software/bluelib/api/json/deserializer/range/ShortRange.java
+++ b/common/src/main/java/software/bluelib/api/json/deserializer/range/ShortRange.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2024 BlueLib Contributors
+ *
+ * This Source Code Form is subject to the terms of the MIT License.
+ * If a copy of the MIT License was not distributed with this file,
+ * You can obtain one at https://opensource.org/licenses/MIT.
+ */
+package software.bluelib.api.json.deserializer.range;
+
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import net.minecraft.util.GsonHelper;
+import org.jetbrains.annotations.NotNull;
+
+public record ShortRange(
+		@NotNull Short min,
+		@NotNull Short max) {
+
+	@NotNull
+	public static JsonDeserializer<ShortRange> deserializer() throws JsonParseException {
+		return (json, type, context) -> {
+			JsonObject obj = json.getAsJsonObject();
+
+			Short min = GsonHelper.getAsShort(obj, "min", (short) 0);
+			Short max = GsonHelper.getAsShort(obj, "max", (short) 100);
+
+			return new ShortRange(
+					min,
+					max);
+		};
+	}
+}

--- a/common/src/main/java/software/bluelib/api/molang/MoLangRuntimeBuilder.java
+++ b/common/src/main/java/software/bluelib/api/molang/MoLangRuntimeBuilder.java
@@ -13,7 +13,7 @@ import java.util.Map;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import software.bluelib.api.molang.context.BaseMoLangContext;
-import software.bluelib.api.molang.registry.MoLangContextRegistry;
+import software.bluelib.internal.registry.molang.BlueMoLangContextRegistry;
 
 @SuppressWarnings({ "unused" })
 public class MoLangRuntimeBuilder {
@@ -47,7 +47,7 @@ public class MoLangRuntimeBuilder {
 	}
 
 	public @NotNull MoLangRuntime build() {
-		List<BaseMoLangContext> contexts = MoLangContextRegistry.createContexts(input);
+		List<BaseMoLangContext> contexts = BlueMoLangContextRegistry.createContexts(input);
 		return new MoLangRuntime(contexts);
 	}
 }

--- a/common/src/main/java/software/bluelib/api/utils/DataUtils.java
+++ b/common/src/main/java/software/bluelib/api/utils/DataUtils.java
@@ -11,13 +11,13 @@ import java.util.Objects;
 import net.minecraft.core.component.DataComponentType;
 import net.minecraft.core.component.PatchedDataComponentMap;
 import org.jetbrains.annotations.NotNull;
-import software.bluelib.BlueLibConstants;
+import software.bluelib.internal.registry.BlueDataComponentRegistry;
 
 @SuppressWarnings("unused")
 public class DataUtils {
 
 	public static boolean areComponentsMatchingIgnoringBlueId(@NotNull PatchedDataComponentMap pComponentMap, @NotNull PatchedDataComponentMap pComponentMapTwo) {
-		final DataComponentType<Long> stackId = BlueLibConstants.STACK_ANIMATABLE_ID_COMPONENT.get();
+		final DataComponentType<Long> stackId = BlueDataComponentRegistry.STACK_ANIMATABLE_ID.get();
 		boolean patched = false;
 
 		if (pComponentMap.has(stackId)) {

--- a/common/src/main/java/software/bluelib/internal/registry/BlueDataComponentRegistry.java
+++ b/common/src/main/java/software/bluelib/internal/registry/BlueDataComponentRegistry.java
@@ -8,25 +8,42 @@
 package software.bluelib.internal.registry;
 
 import com.mojang.serialization.Codec;
-import java.util.function.Supplier;
 import net.minecraft.core.component.DataComponentType;
 import net.minecraft.network.codec.ByteBufCodecs;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import software.bluelib.BlueLibConstants;
-import software.bluelib.api.json.cache.IntRangeCache;
+import software.bluelib.api.json.cache.range.*;
+
+import java.util.function.Supplier;
 
 @ApiStatus.Internal
-@SuppressWarnings({ "unused" })
+@SuppressWarnings({"unused"})
 public class BlueDataComponentRegistry {
 
-	public static void init() {}
+	public static void init() {
+	}
 
 	@NotNull
 	public static final Supplier<DataComponentType<Long>> STACK_ANIMATABLE_ID = registerData("stack_animatable_id", () -> DataComponentType.<Long>builder().persistent(Codec.LONG).networkSynchronized(ByteBufCodecs.VAR_LONG).build());
 
 	@NotNull
 	public static final Supplier<DataComponentType<IntRangeCache>> INT_RANGE = registerData("int_range", () -> IntRangeCache.INT_RANGE_DATA);
+
+	@NotNull
+	public static final Supplier<DataComponentType<ByteRangeCache>> BYTE_RANGE = registerData("byte_range", () -> ByteRangeCache.BYTE_RANGE_DATA);
+
+	@NotNull
+	public static final Supplier<DataComponentType<DoubleRangeCache>> DOUBLE_RANGE = registerData("double_range", () -> DoubleRangeCache.DOUBLE_RANGE_DATA);
+
+	@NotNull
+	public static final Supplier<DataComponentType<FloatRangeCache>> FLOAT_RANGE = registerData("float_range", () -> FloatRangeCache.FLOAT_RANGE_DATA);
+
+	@NotNull
+	public static final Supplier<DataComponentType<LongRangeCache>> LONG_RANGE = registerData("long_range", () -> LongRangeCache.LONG_RANGE_DATA);
+
+	@NotNull
+	public static final Supplier<DataComponentType<ShortRangeCache>> SHORT_RANGE = registerData("short_range", () -> ShortRangeCache.SHORT_RANGE_DATA);
 
 	@NotNull
 	private static <T> Supplier<DataComponentType<T>> registerData(@NotNull String pId, @NotNull Supplier<DataComponentType<T>> pBuilder) {

--- a/common/src/main/java/software/bluelib/internal/registry/BlueDataComponentRegistry.java
+++ b/common/src/main/java/software/bluelib/internal/registry/BlueDataComponentRegistry.java
@@ -14,6 +14,8 @@ import net.minecraft.network.codec.ByteBufCodecs;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import software.bluelib.BlueLibConstants;
+import software.bluelib.api.json.cache.color.RGBAColorCache;
+import software.bluelib.api.json.cache.color.RGBColorCache;
 import software.bluelib.api.json.cache.pos.BlockPosCache;
 import software.bluelib.api.json.cache.pos.Vector2Cache;
 import software.bluelib.api.json.cache.pos.Vector3Cache;
@@ -47,6 +49,11 @@ public class BlueDataComponentRegistry {
 	public static final Supplier<DataComponentType<Vector3Cache>> VECTOR_3 = registerData("vector_three", () -> Vector3Cache.VECTOR3_DATA);
 	@NotNull
 	public static final Supplier<DataComponentType<BlockPosCache>> BLOCK_POS = registerData("block_pos", () -> BlockPosCache.BLOCK_POS_DATA);
+
+	@NotNull
+	public static final Supplier<DataComponentType<RGBAColorCache>> RGBA_COLOR = registerData("rgba_color", () -> RGBAColorCache.RGBA_COLOR_DATA);
+	@NotNull
+	public static final Supplier<DataComponentType<RGBColorCache>> RGB_COLOR = registerData("rgb_color", () -> RGBColorCache.RGB_COLOR_DATA);
 
 	@NotNull
 	private static <T> Supplier<DataComponentType<T>> registerData(@NotNull String pId, @NotNull Supplier<DataComponentType<T>> pBuilder) {

--- a/common/src/main/java/software/bluelib/internal/registry/BlueDataComponentRegistry.java
+++ b/common/src/main/java/software/bluelib/internal/registry/BlueDataComponentRegistry.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2024 BlueLib Contributors
+ *
+ * This Source Code Form is subject to the terms of the MIT License.
+ * If a copy of the MIT License was not distributed with this file,
+ * You can obtain one at https://opensource.org/licenses/MIT.
+ */
+package software.bluelib.internal.registry;
+
+import com.mojang.serialization.Codec;
+import java.util.function.Supplier;
+import net.minecraft.core.component.DataComponentType;
+import net.minecraft.network.codec.ByteBufCodecs;
+import org.jetbrains.annotations.ApiStatus;
+import org.jetbrains.annotations.NotNull;
+import software.bluelib.BlueLibConstants;
+
+@ApiStatus.Internal
+@SuppressWarnings({ "unused" })
+public class BlueDataComponentRegistry {
+
+	public static void init() {}
+
+	@NotNull
+	public static final Supplier<DataComponentType<Long>> STACK_ANIMATABLE_ID = registerData("stack_animatable_id", () -> DataComponentType.<Long>builder().persistent(Codec.LONG).networkSynchronized(ByteBufCodecs.VAR_LONG).build());
+
+	//@NotNull
+	//public static final Supplier<DataComponentType<BoneCache>> BONE = registerData("bone", () -> BoneCache.BONE_DATA);
+
+	@NotNull
+	private static <T> Supplier<DataComponentType<T>> registerData(@NotNull String pId, @NotNull Supplier<DataComponentType<T>> pBuilder) {
+		return BlueLibConstants.PlatformHelper.REGISTRY.registerDataComponent(pId, pBuilder);
+	}
+}

--- a/common/src/main/java/software/bluelib/internal/registry/BlueDataComponentRegistry.java
+++ b/common/src/main/java/software/bluelib/internal/registry/BlueDataComponentRegistry.java
@@ -14,6 +14,7 @@ import net.minecraft.network.codec.ByteBufCodecs;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import software.bluelib.BlueLibConstants;
+import software.bluelib.api.json.cache.IntRangeCache;
 
 @ApiStatus.Internal
 @SuppressWarnings({ "unused" })
@@ -24,8 +25,8 @@ public class BlueDataComponentRegistry {
 	@NotNull
 	public static final Supplier<DataComponentType<Long>> STACK_ANIMATABLE_ID = registerData("stack_animatable_id", () -> DataComponentType.<Long>builder().persistent(Codec.LONG).networkSynchronized(ByteBufCodecs.VAR_LONG).build());
 
-	//@NotNull
-	//public static final Supplier<DataComponentType<BoneCache>> BONE = registerData("bone", () -> BoneCache.BONE_DATA);
+	@NotNull
+	public static final Supplier<DataComponentType<IntRangeCache>> INT_RANGE = registerData("int_range", () -> IntRangeCache.INT_RANGE_DATA);
 
 	@NotNull
 	private static <T> Supplier<DataComponentType<T>> registerData(@NotNull String pId, @NotNull Supplier<DataComponentType<T>> pBuilder) {

--- a/common/src/main/java/software/bluelib/internal/registry/BlueDataComponentRegistry.java
+++ b/common/src/main/java/software/bluelib/internal/registry/BlueDataComponentRegistry.java
@@ -8,42 +8,45 @@
 package software.bluelib.internal.registry;
 
 import com.mojang.serialization.Codec;
+import java.util.function.Supplier;
 import net.minecraft.core.component.DataComponentType;
 import net.minecraft.network.codec.ByteBufCodecs;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import software.bluelib.BlueLibConstants;
+import software.bluelib.api.json.cache.pos.BlockPosCache;
+import software.bluelib.api.json.cache.pos.Vector2Cache;
+import software.bluelib.api.json.cache.pos.Vector3Cache;
 import software.bluelib.api.json.cache.range.*;
 
-import java.util.function.Supplier;
-
 @ApiStatus.Internal
-@SuppressWarnings({"unused"})
+@SuppressWarnings({ "unused" })
 public class BlueDataComponentRegistry {
 
-	public static void init() {
-	}
+	public static void init() {}
 
 	@NotNull
 	public static final Supplier<DataComponentType<Long>> STACK_ANIMATABLE_ID = registerData("stack_animatable_id", () -> DataComponentType.<Long>builder().persistent(Codec.LONG).networkSynchronized(ByteBufCodecs.VAR_LONG).build());
 
 	@NotNull
 	public static final Supplier<DataComponentType<IntRangeCache>> INT_RANGE = registerData("int_range", () -> IntRangeCache.INT_RANGE_DATA);
-
 	@NotNull
 	public static final Supplier<DataComponentType<ByteRangeCache>> BYTE_RANGE = registerData("byte_range", () -> ByteRangeCache.BYTE_RANGE_DATA);
-
 	@NotNull
 	public static final Supplier<DataComponentType<DoubleRangeCache>> DOUBLE_RANGE = registerData("double_range", () -> DoubleRangeCache.DOUBLE_RANGE_DATA);
-
 	@NotNull
 	public static final Supplier<DataComponentType<FloatRangeCache>> FLOAT_RANGE = registerData("float_range", () -> FloatRangeCache.FLOAT_RANGE_DATA);
-
 	@NotNull
 	public static final Supplier<DataComponentType<LongRangeCache>> LONG_RANGE = registerData("long_range", () -> LongRangeCache.LONG_RANGE_DATA);
-
 	@NotNull
 	public static final Supplier<DataComponentType<ShortRangeCache>> SHORT_RANGE = registerData("short_range", () -> ShortRangeCache.SHORT_RANGE_DATA);
+
+	@NotNull
+	public static final Supplier<DataComponentType<Vector2Cache>> VECTOR_2 = registerData("vector_two", () -> Vector2Cache.VECTOR2_DATA);
+	@NotNull
+	public static final Supplier<DataComponentType<Vector3Cache>> VECTOR_3 = registerData("vector_three", () -> Vector3Cache.VECTOR3_DATA);
+	@NotNull
+	public static final Supplier<DataComponentType<BlockPosCache>> BLOCK_POS = registerData("block_pos", () -> BlockPosCache.BLOCK_POS_DATA);
 
 	@NotNull
 	private static <T> Supplier<DataComponentType<T>> registerData(@NotNull String pId, @NotNull Supplier<DataComponentType<T>> pBuilder) {

--- a/common/src/main/java/software/bluelib/internal/registry/molang/BlueMoLangContextRegistry.java
+++ b/common/src/main/java/software/bluelib/internal/registry/molang/BlueMoLangContextRegistry.java
@@ -5,13 +5,14 @@
  * If a copy of the MIT License was not distributed with this file,
  * You can obtain one at https://opensource.org/licenses/MIT.
  */
-package software.bluelib.api.molang.registry;
+package software.bluelib.internal.registry.molang;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import net.minecraft.world.entity.Entity;
+import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import software.bluelib.api.molang.MoLangRuntimeBuilder;
@@ -23,17 +24,18 @@ import software.bluelib.api.molang.context.math.RandomMoLang;
 import software.bluelib.api.molang.context.math.TrigMoLang;
 import software.bluelib.loader.animation.AnimationState;
 
-public class MoLangContextRegistry {
+@ApiStatus.Internal
+public class BlueMoLangContextRegistry {
 
 	public static void init() {
-		MoLangContextRegistry.register(input -> new GeneralMoLang());
-		MoLangContextRegistry.register(input -> new BasicMathMoLang());
-		MoLangContextRegistry.register(input -> new AdvancedMathMoLang());
-		MoLangContextRegistry.register(input -> new RandomMoLang());
-		MoLangContextRegistry.register(input -> new TrigMoLang());
-		MoLangContextRegistry.register(input -> new OperatorMoLang());
+		BlueMoLangContextRegistry.register(input -> new GeneralMoLang());
+		BlueMoLangContextRegistry.register(input -> new BasicMathMoLang());
+		BlueMoLangContextRegistry.register(input -> new AdvancedMathMoLang());
+		BlueMoLangContextRegistry.register(input -> new RandomMoLang());
+		BlueMoLangContextRegistry.register(input -> new TrigMoLang());
+		BlueMoLangContextRegistry.register(input -> new OperatorMoLang());
 
-		MoLangContextRegistry.register(input -> {
+		BlueMoLangContextRegistry.register(input -> {
 			Supplier<?> supplier = input.get("bluelib_state", Supplier.class);
 			if (supplier != null) {
 				Object value = supplier.get();
@@ -44,9 +46,9 @@ public class MoLangContextRegistry {
 			return null;
 		});
 
-		MoLangEntityRegistry.init();
+		BlueMoLangEntityRegistry.init();
 
-		MoLangContextRegistry.register(input -> {
+		BlueMoLangContextRegistry.register(input -> {
 			Supplier<?> supplier = input.get("bluelib_entity", Supplier.class);
 			if (supplier != null) {
 				Object obj = supplier.get();

--- a/common/src/main/java/software/bluelib/internal/registry/molang/BlueMoLangEntityRegistry.java
+++ b/common/src/main/java/software/bluelib/internal/registry/molang/BlueMoLangEntityRegistry.java
@@ -5,7 +5,7 @@
  * If a copy of the MIT License was not distributed with this file,
  * You can obtain one at https://opensource.org/licenses/MIT.
  */
-package software.bluelib.api.molang.registry;
+package software.bluelib.internal.registry.molang;
 
 import net.minecraft.world.entity.*;
 import net.minecraft.world.entity.animal.Animal;
@@ -24,6 +24,7 @@ import net.minecraft.world.entity.npc.Villager;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.entity.raid.Raider;
 import net.minecraft.world.entity.vehicle.VehicleEntity;
+import org.jetbrains.annotations.ApiStatus;
 import software.bluelib.api.molang.context.entity.*;
 import software.bluelib.api.molang.context.entity.animal.*;
 import software.bluelib.api.molang.context.entity.decoration.ArmorStandMoLang;
@@ -37,7 +38,8 @@ import software.bluelib.api.molang.context.entity.monster.PatrollingMonsterMoLan
 import software.bluelib.api.molang.context.entity.npc.AbstractVillagerMoLang;
 import software.bluelib.api.molang.context.entity.vehicle.VehicleEntityMoLang;
 
-public class MoLangEntityRegistry extends MoLangContextRegistry {
+@ApiStatus.Internal
+public class BlueMoLangEntityRegistry extends BlueMoLangContextRegistry {
 
 	public static void init() {
 		registerEntityContext(wolf -> wolf instanceof Wolf ? new WolfMoLang(() -> (Wolf) wolf) : null);

--- a/common/src/main/java/software/bluelib/loader/animatable/item/BlueItem.java
+++ b/common/src/main/java/software/bluelib/loader/animatable/item/BlueItem.java
@@ -16,8 +16,8 @@ import net.minecraft.world.item.ItemDisplayContext;
 import net.minecraft.world.item.ItemStack;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import software.bluelib.BlueLibConstants;
 import software.bluelib.client.utils.RenderUtils;
+import software.bluelib.internal.registry.BlueDataComponentRegistry;
 import software.bluelib.loader.animatable.base.AnimatableManager;
 import software.bluelib.loader.animatable.base.BlueAnimatable;
 import software.bluelib.loader.animatable.base.ContextAwareAnimatableManager;
@@ -34,7 +34,7 @@ public interface BlueItem extends SingletonBlueAnimatable {
 	}
 
 	static long getId(@NotNull ItemStack pStack) {
-		return Optional.ofNullable(pStack.getComponentsPatch().get(BlueLibConstants.STACK_ANIMATABLE_ID_COMPONENT.get()))
+		return Optional.ofNullable(pStack.getComponentsPatch().get(BlueDataComponentRegistry.STACK_ANIMATABLE_ID.get()))
 				.filter(Optional::isPresent)
 				.<Long>map(Optional::get)
 				.orElse(Long.MAX_VALUE);
@@ -44,10 +44,10 @@ public interface BlueItem extends SingletonBlueAnimatable {
 		if (!(pStack.getComponents() instanceof PatchedDataComponentMap components))
 			return Long.MAX_VALUE;
 
-		Long id = components.get(BlueLibConstants.STACK_ANIMATABLE_ID_COMPONENT.get());
+		Long id = components.get(BlueDataComponentRegistry.STACK_ANIMATABLE_ID.get());
 
 		if (id == null)
-			components.set(BlueLibConstants.STACK_ANIMATABLE_ID_COMPONENT.get(), id = IdCache.getFreeId(pLevel));
+			components.set(BlueDataComponentRegistry.STACK_ANIMATABLE_ID.get(), id = IdCache.getFreeId(pLevel));
 
 		return id;
 	}

--- a/common/src/main/java/software/bluelib/loader/renderer/entity/EntityRenderUtils.java
+++ b/common/src/main/java/software/bluelib/loader/renderer/entity/EntityRenderUtils.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright (C) 2024 BlueLib Contributors
+ *
+ * This Source Code Form is subject to the terms of the MIT License.
+ * If a copy of the MIT License was not distributed with this file,
+ * You can obtain one at https://opensource.org/licenses/MIT.
+ */
 package software.bluelib.loader.renderer.entity;
 
 import com.mojang.blaze3d.vertex.PoseStack;

--- a/common/src/main/java/software/bluelib/mixin/common/loader/AbstractContainerMenuMixin.java
+++ b/common/src/main/java/software/bluelib/mixin/common/loader/AbstractContainerMenuMixin.java
@@ -14,7 +14,7 @@ import net.minecraft.world.item.ItemStack;
 import org.jetbrains.annotations.NotNull;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import software.bluelib.BlueLibConstants;
+import software.bluelib.internal.registry.BlueDataComponentRegistry;
 
 @Mixin(AbstractContainerMenu.class)
 public class AbstractContainerMenuMixin {
@@ -23,19 +23,19 @@ public class AbstractContainerMenuMixin {
 	public ItemStack BlueLib$removeBlueLibIdOnCopy(@NotNull ItemStack pInstance, int pCount, @NotNull Operation<ItemStack> pOriginal) {
 		ItemStack copy = pOriginal.call(pInstance, pCount);
 
-		if (copy.has(BlueLibConstants.STACK_ANIMATABLE_ID_COMPONENT.get()))
-			copy.remove(BlueLibConstants.STACK_ANIMATABLE_ID_COMPONENT.get());
+		if (copy.has(BlueDataComponentRegistry.STACK_ANIMATABLE_ID.get()))
+			copy.remove(BlueDataComponentRegistry.STACK_ANIMATABLE_ID.get());
 
 		return copy;
 	}
 
 	@WrapOperation(method = "synchronizeSlotToRemote", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/item/ItemStack;matches(Lnet/minecraft/world/item/ItemStack;Lnet/minecraft/world/item/ItemStack;)Z"))
 	public boolean BlueLib$forceBlueLibIdSync(@NotNull ItemStack pStack, @NotNull ItemStack pOther, @NotNull Operation<Boolean> pOriginal) {
-		return pOriginal.call(pStack, pOther) && pStack.getOrDefault(BlueLibConstants.STACK_ANIMATABLE_ID_COMPONENT.get(), -1).equals(pOther.getOrDefault(BlueLibConstants.STACK_ANIMATABLE_ID_COMPONENT.get(), -1));
+		return pOriginal.call(pStack, pOther) && pStack.getOrDefault(BlueDataComponentRegistry.STACK_ANIMATABLE_ID.get(), -1).equals(pOther.getOrDefault(BlueDataComponentRegistry.STACK_ANIMATABLE_ID.get(), -1));
 	}
 
 	@WrapOperation(method = "triggerSlotListeners", at = @At(value = "INVOKE", target = "Lnet/minecraft/world/item/ItemStack;matches(Lnet/minecraft/world/item/ItemStack;Lnet/minecraft/world/item/ItemStack;)Z"))
 	public boolean BlueLib$forceBlueLibSlotChange(@NotNull ItemStack pStack, @NotNull ItemStack pOther, @NotNull Operation<Boolean> pOriginal) {
-		return pOriginal.call(pStack, pOther) && pStack.getOrDefault(BlueLibConstants.STACK_ANIMATABLE_ID_COMPONENT.get(), -1).equals(pOther.getOrDefault(BlueLibConstants.STACK_ANIMATABLE_ID_COMPONENT.get(), -1));
+		return pOriginal.call(pStack, pOther) && pStack.getOrDefault(BlueDataComponentRegistry.STACK_ANIMATABLE_ID.get(), -1).equals(pOther.getOrDefault(BlueDataComponentRegistry.STACK_ANIMATABLE_ID.get(), -1));
 	}
 }

--- a/common/src/main/java/software/bluelib/mixin/common/loader/ItemStackMixin.java
+++ b/common/src/main/java/software/bluelib/mixin/common/loader/ItemStackMixin.java
@@ -14,8 +14,8 @@ import net.minecraft.world.item.ItemStack;
 import org.jetbrains.annotations.NotNull;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import software.bluelib.BlueLibConstants;
 import software.bluelib.api.utils.DataUtils;
+import software.bluelib.internal.registry.BlueDataComponentRegistry;
 
 @Mixin(ItemStack.class)
 public class ItemStackMixin {
@@ -24,8 +24,8 @@ public class ItemStackMixin {
 	public @NotNull ItemStack BlueLib$removeBlueLibIdOnCopy(@NotNull ItemStack pInstance, int pCount, @NotNull Operation<ItemStack> pOriginal) {
 		ItemStack copy = pOriginal.call(pInstance, pCount);
 
-		if (pCount < pInstance.getCount() && copy.has(BlueLibConstants.STACK_ANIMATABLE_ID_COMPONENT.get()))
-			copy.remove(BlueLibConstants.STACK_ANIMATABLE_ID_COMPONENT.get());
+		if (pCount < pInstance.getCount() && copy.has(BlueDataComponentRegistry.STACK_ANIMATABLE_ID.get()))
+			copy.remove(BlueDataComponentRegistry.STACK_ANIMATABLE_ID.get());
 
 		return copy;
 	}

--- a/common/src/main/java/software/bluelib/platform/IRegistryHelper.java
+++ b/common/src/main/java/software/bluelib/platform/IRegistryHelper.java
@@ -8,7 +8,6 @@
 package software.bluelib.platform;
 
 import java.util.function.Supplier;
-import java.util.function.UnaryOperator;
 import net.minecraft.core.component.DataComponentType;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.EntityType;
@@ -32,5 +31,5 @@ public interface IRegistryHelper {
 	<T extends Entity> Supplier<EntityType<T>> registerEntity(@NotNull String pId, @NotNull Supplier<EntityType<T>> pEntity);
 
 	@NotNull
-	<T> Supplier<DataComponentType<T>> registerDataComponent(@NotNull String pId, @NotNull UnaryOperator<DataComponentType.Builder<T>> pBuilder);
+	<T extends DataComponentType<?>> Supplier<T> registerDataComponent(@NotNull String pId, @NotNull Supplier<T> pDataComponentType);
 }

--- a/fabric/src/main/java/software/bluelib/platform/FabricRegistryHelper.java
+++ b/fabric/src/main/java/software/bluelib/platform/FabricRegistryHelper.java
@@ -8,7 +8,6 @@
 package software.bluelib.platform;
 
 import java.util.function.Supplier;
-import java.util.function.UnaryOperator;
 import net.minecraft.core.Holder;
 import net.minecraft.core.Registry;
 import net.minecraft.core.component.DataComponentType;
@@ -21,7 +20,6 @@ import net.minecraft.world.item.crafting.RecipeType;
 import org.jetbrains.annotations.NotNull;
 import software.bluelib.BlueLibConstants;
 import software.bluelib.api.net.NetworkManager;
-import software.bluelib.internal.BlueResource;
 import software.bluelib.net.FabricNetworkManager;
 
 @SuppressWarnings({ "unchecked", "unused" })
@@ -48,10 +46,8 @@ public class FabricRegistryHelper implements IRegistryHelper {
 	}
 
 	@Override
-	public <T> @NotNull Supplier<DataComponentType<T>> registerDataComponent(@NotNull String pId, @NotNull UnaryOperator<DataComponentType.Builder<T>> pBuilder) {
-		final DataComponentType<T> componentType = Registry.register(BuiltInRegistries.DATA_COMPONENT_TYPE, BlueResource.resource(pId).toString(), pBuilder.apply(DataComponentType.builder()).build());
-
-		return () -> componentType;
+	public <T extends DataComponentType<?>> @NotNull Supplier<T> registerDataComponent(@NotNull String pId, @NotNull Supplier<T> pDataComponentType) {
+		return registerSupplier(BuiltInRegistries.DATA_COMPONENT_TYPE, pId, pDataComponentType);
 	}
 
 	@NotNull

--- a/neoforge/src/main/java/software/bluelib/platform/NeoForgeRegistryHelper.java
+++ b/neoforge/src/main/java/software/bluelib/platform/NeoForgeRegistryHelper.java
@@ -8,7 +8,6 @@
 package software.bluelib.platform;
 
 import java.util.function.Supplier;
-import java.util.function.UnaryOperator;
 import net.minecraft.core.component.DataComponentType;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.world.entity.Entity;
@@ -27,7 +26,7 @@ import software.bluelib.net.NeoForgeNetworkManager;
 public class NeoForgeRegistryHelper implements IRegistryHelper {
 
 	@NotNull
-	public static final DeferredRegister.DataComponents DATA_COMPONENTS_REGISTER = DeferredRegister.createDataComponents(Registries.DATA_COMPONENT_TYPE, BlueLibConstants.MOD_ID);
+	public static final DeferredRegister.DataComponents DATA_COMPONENT_TYPE = DeferredRegister.createDataComponents(Registries.DATA_COMPONENT_TYPE, BlueLibConstants.MOD_ID);
 	@NotNull
 	public static final DeferredRegister<EntityType<?>> ENTITIES = DeferredRegister.create(Registries.ENTITY_TYPE, BlueLibConstants.MOD_ID);
 	@NotNull
@@ -51,8 +50,8 @@ public class NeoForgeRegistryHelper implements IRegistryHelper {
 	}
 
 	@Override
-	public <T> @NotNull Supplier<DataComponentType<T>> registerDataComponent(@NotNull String pId, @NotNull UnaryOperator<DataComponentType.Builder<T>> pBuilder) {
-		return DATA_COMPONENTS_REGISTER.registerComponentType(pId, pBuilder);
+	public <T extends DataComponentType<?>> @NotNull Supplier<T> registerDataComponent(@NotNull String pId, @NotNull Supplier<T> pDataComponentType) {
+		return DATA_COMPONENT_TYPE.register(pId, pDataComponentType);
 	}
 
 	@Override
@@ -63,7 +62,7 @@ public class NeoForgeRegistryHelper implements IRegistryHelper {
 	public static void register(@NotNull IEventBus pModEventBus) {
 		RECIPE_TYPES.register(pModEventBus);
 		RECIPE_SERIALIZERS.register(pModEventBus);
-		DATA_COMPONENTS_REGISTER.register(pModEventBus);
+		DATA_COMPONENT_TYPE.register(pModEventBus);
 		ENTITIES.register(pModEventBus);
 
 		pModEventBus.<EntityAttributeCreationEvent>addListener(event -> BlueEntityRegistry.registerEntityAttributes(event::put));


### PR DESCRIPTION
* Added Preset Caches with Json Deserializers, Codecs, DataComponentType and CompoundTags for easy saving/loading of
  presets.
    * IntRange
    * FloatRange
    * DoubleRange
    * LongRange
    * ShortRange
    * ByteRange
    * BlockPos (With conversion from BlockPosCache to BlockPos)
    * Vector2 (as Float) (With conversion from Vector2Cache to Vector2f)
    * Vector3 (as Float) (With conversion from Vector3Cache to Vector3f)
    * RGBAColor (With conversion from RGBAColorCache to Color)
    * RGBColor (With conversion from RGBColorCache to Color)
* Added `DataComponentType` for easy registration of custom data components.